### PR TITLE
Reduced generic constraint on Complex scalar type from BinaryFloatingPoint to Numeric

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -59,5 +59,6 @@ reporter: "xcode"
 
 identifier_name:
   excluded:
+    - i
     - pi
     - _value

--- a/Complex.xcodeproj/project.pbxproj
+++ b/Complex.xcodeproj/project.pbxproj
@@ -38,12 +38,40 @@
 		DDB8122123F656AC0079FEB5 /* FunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8122023F656AC0079FEB5 /* FunctionsTests.swift */; };
 		DDB8122223F656AC0079FEB5 /* FunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8122023F656AC0079FEB5 /* FunctionsTests.swift */; };
 		DDB8122323F656AC0079FEB5 /* FunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8122023F656AC0079FEB5 /* FunctionsTests.swift */; };
+		DDB8126223F7B1C90079FEB5 /* ComplexArithmetic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8126123F7B1C90079FEB5 /* ComplexArithmetic.swift */; };
+		DDB8126323F7B1C90079FEB5 /* ComplexArithmetic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8126123F7B1C90079FEB5 /* ComplexArithmetic.swift */; };
+		DDB8126423F7B1C90079FEB5 /* ComplexArithmetic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8126123F7B1C90079FEB5 /* ComplexArithmetic.swift */; };
+		DDB8126523F7B1C90079FEB5 /* ComplexArithmetic.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8126123F7B1C90079FEB5 /* ComplexArithmetic.swift */; };
+		DDB8126723F7B7F40079FEB5 /* ComplexArithmeticTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8126623F7B7F40079FEB5 /* ComplexArithmeticTests.swift */; };
+		DDB8126823F7B7F40079FEB5 /* ComplexArithmeticTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8126623F7B7F40079FEB5 /* ComplexArithmeticTests.swift */; };
+		DDB8126923F7B7F40079FEB5 /* ComplexArithmeticTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8126623F7B7F40079FEB5 /* ComplexArithmeticTests.swift */; };
 		DDFEEC3D23EF13910096015C /* Complex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFEEC3323EF13900096015C /* Complex.framework */; };
 		DDFEECC723F2001A0096015C /* Complex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFEECBE23F2001A0096015C /* Complex.framework */; };
 		DDFEECE323F2003E0096015C /* Complex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFEECDA23F2003E0096015C /* Complex.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		DDB8127B23FA5C3E0079FEB5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDFEEC2A23EF13900096015C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDFEECA423F1BA0B0096015C;
+			remoteInfo = "Run SwiftLint";
+		};
+		DDB8127F23FA5C430079FEB5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDFEEC2A23EF13900096015C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDFEECA423F1BA0B0096015C;
+			remoteInfo = "Run SwiftLint";
+		};
+		DDB8128323FA5C480079FEB5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDFEEC2A23EF13900096015C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDFEECA423F1BA0B0096015C;
+			remoteInfo = "Run SwiftLint";
+		};
 		DDFEEC3E23EF13910096015C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DDFEEC2A23EF13900096015C /* Project object */;
@@ -83,6 +111,8 @@
 		DDB8121B23F63B890079FEB5 /* Half.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Half.framework; path = Carthage/Build/Mac/Half.framework; sourceTree = "<group>"; };
 		DDB8121C23F63B900079FEB5 /* Half.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Half.framework; path = Carthage/Build/iOS/Half.framework; sourceTree = "<group>"; };
 		DDB8122023F656AC0079FEB5 /* FunctionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionsTests.swift; sourceTree = "<group>"; };
+		DDB8126123F7B1C90079FEB5 /* ComplexArithmetic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplexArithmetic.swift; sourceTree = "<group>"; };
+		DDB8126623F7B7F40079FEB5 /* ComplexArithmeticTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComplexArithmeticTests.swift; sourceTree = "<group>"; };
 		DDFEEC3323EF13900096015C /* Complex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Complex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDFEEC3723EF13900096015C /* Complex-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Complex-Info.plist"; path = "Info/Complex-Info.plist"; sourceTree = "<group>"; };
 		DDFEEC3C23EF13910096015C /* ComplexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ComplexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -214,6 +244,7 @@
 			isa = PBXGroup;
 			children = (
 				DDB8121023F5AEB10079FEB5 /* ComplexTests.swift */,
+				DDB8126623F7B7F40079FEB5 /* ComplexArithmeticTests.swift */,
 				DDB8122023F656AC0079FEB5 /* FunctionsTests.swift */,
 				DDFEEC4323EF13910096015C /* ComplexTests-Info.plist */,
 			);
@@ -247,6 +278,7 @@
 			isa = PBXGroup;
 			children = (
 				DDB8120623F59B760079FEB5 /* Complex.swift */,
+				DDB8126123F7B1C90079FEB5 /* ComplexArithmetic.swift */,
 				DDB8120B23F5A8E80079FEB5 /* Functions.swift */,
 			);
 			path = Complex;
@@ -335,6 +367,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DDB8127C23FA5C3E0079FEB5 /* PBXTargetDependency */,
 			);
 			name = "Complex macOS";
 			productName = "Complex macOS";
@@ -371,6 +404,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DDB8128023FA5C430079FEB5 /* PBXTargetDependency */,
 			);
 			name = "Complex tvOS";
 			productName = "Complex tvOS";
@@ -407,6 +441,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DDB8128423FA5C480079FEB5 /* PBXTargetDependency */,
 			);
 			name = "Complex watchOS";
 			productName = "Complex watchOS";
@@ -559,6 +594,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDB8126223F7B1C90079FEB5 /* ComplexArithmetic.swift in Sources */,
 				DDB8120723F59B760079FEB5 /* Complex.swift in Sources */,
 				DDB8120C23F5A8E80079FEB5 /* Functions.swift in Sources */,
 			);
@@ -568,6 +604,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDB8126723F7B7F40079FEB5 /* ComplexArithmeticTests.swift in Sources */,
 				DDB8121123F5AEB10079FEB5 /* ComplexTests.swift in Sources */,
 				DDB8122123F656AC0079FEB5 /* FunctionsTests.swift in Sources */,
 			);
@@ -577,6 +614,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDB8126323F7B1C90079FEB5 /* ComplexArithmetic.swift in Sources */,
 				DDB8120823F59B760079FEB5 /* Complex.swift in Sources */,
 				DDB8120D23F5A8E80079FEB5 /* Functions.swift in Sources */,
 			);
@@ -586,6 +624,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDB8126823F7B7F40079FEB5 /* ComplexArithmeticTests.swift in Sources */,
 				DDB8121223F5AEB10079FEB5 /* ComplexTests.swift in Sources */,
 				DDB8122223F656AC0079FEB5 /* FunctionsTests.swift in Sources */,
 			);
@@ -595,6 +634,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDB8126423F7B1C90079FEB5 /* ComplexArithmetic.swift in Sources */,
 				DDB8120923F59B760079FEB5 /* Complex.swift in Sources */,
 				DDB8120E23F5A8E80079FEB5 /* Functions.swift in Sources */,
 			);
@@ -604,6 +644,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDB8126923F7B7F40079FEB5 /* ComplexArithmeticTests.swift in Sources */,
 				DDB8121323F5AEB10079FEB5 /* ComplexTests.swift in Sources */,
 				DDB8122323F656AC0079FEB5 /* FunctionsTests.swift in Sources */,
 			);
@@ -613,6 +654,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDB8126523F7B1C90079FEB5 /* ComplexArithmetic.swift in Sources */,
 				DDB8120A23F59B760079FEB5 /* Complex.swift in Sources */,
 				DDB8120F23F5A8E80079FEB5 /* Functions.swift in Sources */,
 			);
@@ -621,6 +663,21 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		DDB8127C23FA5C3E0079FEB5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DDFEECA423F1BA0B0096015C /* Run SwiftLint */;
+			targetProxy = DDB8127B23FA5C3E0079FEB5 /* PBXContainerItemProxy */;
+		};
+		DDB8128023FA5C430079FEB5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DDFEECA423F1BA0B0096015C /* Run SwiftLint */;
+			targetProxy = DDB8127F23FA5C430079FEB5 /* PBXContainerItemProxy */;
+		};
+		DDB8128423FA5C480079FEB5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DDFEECA423F1BA0B0096015C /* Run SwiftLint */;
+			targetProxy = DDB8128323FA5C480079FEB5 /* PBXContainerItemProxy */;
+		};
 		DDFEEC3F23EF13910096015C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DDFEEC3223EF13900096015C /* Complex */;

--- a/Sources/Complex/Complex.swift
+++ b/Sources/Complex/Complex.swift
@@ -7,91 +7,149 @@
 
 import Foundation
 
-//swiftlint:disable shorthand_operator
-
 // MARK: - Complex Definition
 
-@frozen public struct Complex<FloatingPoint: BinaryFloatingPoint> {
+@frozen public struct Complex<Scalar: Numeric> {
 
     // MARK: Public Properties
 
-    public var real: FloatingPoint
-    public var imaginary: FloatingPoint
+    public var real: Scalar
+    public var imaginary: Scalar
 
     // MARK: Initialization
 
     @_transparent
-    public init(real: FloatingPoint = 0.0, imaginary: FloatingPoint = 0.0) {
+    public init(real: Scalar = .zero, imaginary: Scalar = .zero) {
         self.real = real
         self.imaginary = imaginary
     }
 
     @_transparent
-    public init<Source>(real: Source, imaginary: Source) where Source: BinaryFloatingPoint {
-        self.init(real: FloatingPoint(real), imaginary: FloatingPoint(imaginary))
-    }
-
-    @_transparent
-    public init<Source>(real: Source, imaginary: Source) where Source: BinaryInteger {
-        self.init(real: FloatingPoint(real), imaginary: FloatingPoint(imaginary))
-    }
-
-    @_transparent
-    public init<Source>(_ complex: Complex<Source>) where Source: BinaryFloatingPoint {
-        self.init(real: FloatingPoint(complex.real), imaginary: FloatingPoint(complex.imaginary))
+    public init(_ other: Complex<Scalar>) {
+        self.real = other.real
+        self.imaginary = other.imaginary
     }
 
     @_transparent
     public init() {
-        self.init(real: 0.0, imaginary: 0.0)
+        self.init(real: .zero, imaginary: .zero)
+    }
+}
+
+// MARK: - Complex Initialization Extensions
+
+extension Complex where Scalar: BinaryFloatingPoint {
+
+    @_transparent
+    public init<Source>(real: Source, imaginary: Source) where Source: BinaryFloatingPoint {
+        self.init(real: Scalar(real), imaginary: Scalar(imaginary))
+    }
+
+    @_transparent
+    public init<Source>(_ other: Complex<Source>) where Source: BinaryFloatingPoint {
+        self.init(real: Scalar(other.real), imaginary: Scalar(other.imaginary))
+    }
+}
+
+extension Complex where Scalar: FloatingPoint {
+
+    @_transparent
+    public init<Source>(real: Source, imaginary: Source) where Source: BinaryInteger {
+        self.init(real: Scalar(real), imaginary: Scalar(imaginary))
+    }
+
+    @_transparent
+    public init<Source>(_ other: Complex<Source>) where Source: BinaryInteger {
+        self.init(real: Scalar(other.real), imaginary: Scalar(other.imaginary))
+    }
+}
+
+extension Complex where Scalar: BinaryFloatingPoint, Scalar.RawSignificand: FixedWidthInteger {
+
+    @inlinable
+    public static func random<T>(in range: Range<Scalar>, using generator: inout T) -> Complex where T: RandomNumberGenerator {
+        return Complex(real: Scalar.random(in: range, using: &generator), imaginary: Scalar.random(in: range, using: &generator))
+    }
+
+    @inlinable
+    public static func random(in range: Range<Scalar>) -> Complex {
+        return Complex(real: Scalar.random(in: range), imaginary: Scalar.random(in: range))
+    }
+
+    @inlinable
+    public static func random<T>(in range: ClosedRange<Scalar>, using generator: inout T) -> Complex where T: RandomNumberGenerator {
+        return Complex(real: Scalar.random(in: range, using: &generator), imaginary: Scalar.random(in: range, using: &generator))
+    }
+
+    @inlinable
+    public static func random(in range: ClosedRange<Scalar>) -> Complex {
+        return Complex(real: Scalar.random(in: range), imaginary: Scalar.random(in: range))
+    }
+}
+
+extension Complex where Scalar: BinaryInteger {
+
+    @_transparent
+    public init<Source>(real: Source, imaginary: Source) where Source: BinaryFloatingPoint {
+        self.init(real: Scalar(real), imaginary: Scalar(imaginary))
+    }
+
+    @_transparent
+    public init<Source>(real: Source, imaginary: Source) where Source: BinaryInteger {
+        self.init(real: Scalar(real), imaginary: Scalar(imaginary))
+    }
+
+    //
+
+    @_transparent
+    public init<Source>(_ other: Complex<Source>) where Source: BinaryFloatingPoint {
+        self.init(real: Scalar(other.real), imaginary: Scalar(other.imaginary))
+    }
+
+    @_transparent
+    public init<Source>(_ other: Complex<Source>) where Source: BinaryInteger {
+        self.init(real: Scalar(other.real), imaginary: Scalar(other.imaginary))
+    }
+}
+
+extension Complex where Scalar: FixedWidthInteger {
+
+    @inlinable
+    public static func random<T>(in range: Range<Scalar>, using generator: inout T) -> Complex where T: RandomNumberGenerator {
+        return Complex(real: Scalar.random(in: range, using: &generator), imaginary: Scalar.random(in: range, using: &generator))
+    }
+
+    @inlinable
+    public static func random(in range: Range<Scalar>) -> Complex {
+        return Complex(real: Scalar.random(in: range), imaginary: Scalar.random(in: range))
+    }
+
+    @inlinable
+    public static func random<T>(in range: ClosedRange<Scalar>, using generator: inout T) -> Complex where T: RandomNumberGenerator {
+        return Complex(real: Scalar.random(in: range, using: &generator), imaginary: Scalar.random(in: range, using: &generator))
+    }
+
+    @inlinable
+    public static func random(in range: ClosedRange<Scalar>) -> Complex {
+        return Complex(real: Scalar.random(in: range), imaginary: Scalar.random(in: range))
     }
 }
 
 // MARK: - ExpressibleByArrayLiteral Protocol Conformance
 
-extension Complex: ExpressibleByArrayLiteral {
+extension Complex: ExpressibleByArrayLiteral where Scalar: AdditiveArithmetic {
 
     @_transparent
-    public init(arrayLiteral elements: FloatingPoint...) {
+    public init(arrayLiteral elements: Scalar...) {
         precondition(elements.count <= 2, "Expected at most two elements")
 
         if elements.isEmpty {
             self.init()
         } else if elements.count == 1 {
-            self.init(real: elements[0])
+            self.init(real: elements[0], imaginary: .zero)
         } else {
             self.init(real: elements[0], imaginary: elements[1])
         }
-    }
-}
-
-// MARK: - AdditiveArithmetic Protocol Conformance
-
-extension Complex: AdditiveArithmetic {
-
-    @_transparent
-    public static var zero: Complex {
-        return Complex(real: .zero, imaginary: .zero)
-    }
-
-    @_transparent
-    public static func + (lhs: Complex, rhs: Complex) -> Complex {
-        return Complex(real: lhs.real + rhs.real, imaginary: lhs.imaginary + rhs.imaginary)
-    }
-
-    @_transparent
-    public static func += (lhs: inout Complex, rhs: Complex) {
-        lhs = lhs + rhs
-    }
-
-    @_transparent
-    public static func - (lhs: Complex, rhs: Complex) -> Complex {
-        return Complex(real: lhs.real - rhs.real, imaginary: lhs.imaginary - rhs.imaginary)
-    }
-
-    @_transparent
-    public static func -= (lhs: inout Complex, rhs: Complex) {
-        lhs = lhs - rhs
     }
 }
 
@@ -99,6 +157,7 @@ extension Complex: AdditiveArithmetic {
 
 extension Complex: CustomStringConvertible {
 
+    @_transparent
     public var description: String {
         return "{ real: \(real), imaginary: \(imaginary) }"
     }
@@ -108,6 +167,7 @@ extension Complex: CustomStringConvertible {
 
 extension Complex: CustomDebugStringConvertible {
 
+    @_transparent
     public var debugDescription: String {
         return "{ real: \(real), imaginary: \(imaginary) }"
     }
@@ -115,7 +175,7 @@ extension Complex: CustomDebugStringConvertible {
 
 // MARK: - Hashable Protocol Conformance
 
-extension Complex: Hashable {
+extension Complex: Hashable where Scalar: Hashable {
 
     @inlinable
     public func hash(into hasher: inout Hasher) {
@@ -126,7 +186,7 @@ extension Complex: Hashable {
 
 // MARK: - Equatable Protocol Conformance
 
-extension Complex: Equatable {
+extension Complex: Equatable where Scalar: Equatable {
 
     @_transparent
     public static func == (lhs: Complex, rhs: Complex) -> Bool {
@@ -134,155 +194,52 @@ extension Complex: Equatable {
     }
 }
 
-// MARK: - Codable Protocol Conformance
+// MARK: - Encodable Protocol Conformance
 
-extension Complex: Codable where FloatingPoint: Codable {
+extension Complex: Encodable where Scalar: Encodable {
 
 }
 
-// MARK: - Complex Extension
+// MARK: - Decodable Protocol Conformance
 
-extension Complex {
+extension Complex: Decodable where Scalar: Decodable {
+
+}
+
+// MARK: - Complex BinaryInteger Extensions
+
+extension Complex where Scalar: BinaryInteger {
 
     @_transparent
-    public static func * (lhs: Complex, rhs: Complex) -> Complex {
-        let real = (lhs.real * rhs.real) - (lhs.imaginary * rhs.imaginary)
-        let imaginary = (lhs.real * rhs.imaginary) + (lhs.imaginary * rhs.real)
-
-        return Complex(real: real, imaginary: imaginary)
+    public var modulus: Scalar {
+        return Scalar(sqrt(Float80(real * real + imaginary * imaginary)))
     }
 
     @_transparent
-    public static func *= (lhs: inout Complex, rhs: Complex) {
-        lhs = lhs * rhs
+    public var angle: Scalar {
+        return Scalar(atan2(Float80(imaginary), Float80(real)))
     }
 
-    @_transparent
-    public static func / (lhs: Complex, rhs: Complex) -> Complex {
-        let numerator = lhs * rhs.conjugate()
-        let denominator = rhs * rhs.conjugate() // Multiplying the denominator by its conjugate cancels out its imaginary component
-
-        return Complex(real: numerator.real / denominator.real, imaginary: numerator.imaginary / denominator.real)
-    }
+    //
 
     @_transparent
-    public static func /= (lhs: inout Complex, rhs: Complex) {
-        lhs = lhs / rhs
+    public func string(withNotation notation: Notation) -> String {
+        let string: String
+
+        switch notation {
+        case .square:        string = "\(real) + \(imaginary)i"
+        case .trigonometric: string = "\(modulus) (cos(\(angle)) + i sin(\(angle)))"
+        case .euler:         string = "\(modulus) e ^ (i \(angle))"
+        case .angle:         string = "\(modulus) ⦣ \(angle)"
+        }
+
+        return string
     }
 }
 
-// MARK: - Complex Extension
+// MARK: - Complex FloatingPoint Extensions
 
-extension Complex {
-
-    @_transparent
-    public static func + (lhs: Complex, rhs: FloatingPoint) -> Complex {
-        return Complex(real: lhs.real + rhs, imaginary: lhs.imaginary)
-    }
-
-    @_transparent
-    public static func + (lhs: FloatingPoint, rhs: Complex) -> Complex {
-        return Complex(real: lhs + rhs.real, imaginary: rhs.imaginary)
-    }
-
-    @_transparent
-    public static func += (lhs: inout Complex, rhs: FloatingPoint) {
-        lhs = lhs + rhs
-    }
-
-    @_transparent
-    public static func - (lhs: Complex, rhs: FloatingPoint) -> Complex {
-        return Complex(real: lhs.real - rhs, imaginary: lhs.imaginary)
-    }
-
-    @_transparent
-    public static func - (lhs: FloatingPoint, rhs: Complex) -> Complex {
-        return Complex(real: lhs - rhs.real, imaginary: -rhs.imaginary)
-    }
-
-    @_transparent
-    public static func -= (lhs: inout Complex, rhs: FloatingPoint) {
-        lhs = lhs - rhs
-    }
-
-    @_transparent
-    public static func * (lhs: Complex, rhs: FloatingPoint) -> Complex {
-        return Complex(real: lhs.real * rhs, imaginary: lhs.imaginary * rhs)
-    }
-
-    @_transparent
-    public static func * (lhs: FloatingPoint, rhs: Complex) -> Complex {
-        return Complex(real: lhs * rhs.real, imaginary: lhs * rhs.imaginary)
-    }
-
-    @_transparent
-    public static func *= (lhs: inout Complex, rhs: FloatingPoint) {
-        lhs = lhs * rhs
-    }
-
-    @_transparent
-    public static func / (lhs: Complex, rhs: FloatingPoint) -> Complex {
-        return Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs)
-    }
-
-    @_transparent
-    public static func / (lhs: FloatingPoint, rhs: Complex) -> Complex {
-        return Complex(real: lhs, imaginary: 0.0) / rhs
-    }
-
-    @_transparent
-    public static func /= (lhs: inout Complex, rhs: FloatingPoint) {
-        lhs = lhs / rhs
-    }
-}
-
-// MARK: - Complex Extension
-
-extension Complex {
-
-    @_transparent
-    public mutating func negate() {
-        real.negate()
-        imaginary.negate()
-    }
-
-    @_transparent
-    public static prefix func - (complex: Complex) -> Complex {
-        var value = complex
-        value.negate()
-        return value
-    }
-
-    @_transparent
-    public static prefix func + (complex: Complex) -> Complex {
-        return complex
-    }
-}
-
-// MARK: - Complex Extension
-
-extension Complex {
-
-    @_transparent
-    public static prefix func ~ (complex: Complex) -> Complex {
-        return complex.conjugate()
-    }
-
-    @_transparent
-    public func conjugate() -> Complex {
-        var complex = self
-        complex.formConjugate()
-        return complex
-    }
-
-    public mutating func formConjugate() {
-        imaginary.negate()
-    }
-}
-
-// MARK: - Complex Extension
-
-extension Complex {
+extension Complex where Scalar: FloatingPoint {
 
     @_transparent
     public func rounded(_ rule: FloatingPointRoundingRule) -> Complex {
@@ -293,9 +250,7 @@ extension Complex {
 
     @_transparent
     public func rounded() -> Complex {
-        var complex = self
-        complex.round()
-        return complex
+        rounded(.toNearestOrAwayFromZero)
     }
 
     //
@@ -312,36 +267,24 @@ extension Complex {
     }
 }
 
-// MARK: - Complex Extension
-
-extension Complex {
+extension Complex where Scalar: FloatingPoint {
 
     @_transparent
-    public var modulus: FloatingPoint {
+    public var modulus: Scalar {
         return sqrt(real * real + imaginary * imaginary)
-    }
-
-    public var angle: FloatingPoint {
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        return FloatingPoint(atan2(Float80(imaginary), Float80(real)))
-#else
-        return FloatingPoint(atan2(Double(imaginary), Double(real)))
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     }
 }
 
-// MARK: - Complex Extension
+// MARK: - Complex BinaryFloatingPoint Extensions
 
-extension Complex {
+extension Complex where Scalar: BinaryFloatingPoint {
 
-    public enum Notation: String, Codable, Hashable {
-
-        case square
-        case trigonometric
-        case euler
-        case angle
+    @_transparent
+    public var angle: Scalar {
+        return Scalar(atan2(Float80(imaginary), Float80(real)))
     }
 
+    @_transparent
     public func string(withNotation notation: Notation) -> String {
         let string: String
 
@@ -353,5 +296,82 @@ extension Complex {
         }
 
         return string
+    }
+}
+
+// MARK: - Complex SignedNumeric Extensions
+
+extension Complex where Scalar: SignedNumeric {
+
+    @_transparent
+    public static prefix func ~ (complex: Complex) -> Complex {
+        return complex.conjugate()
+    }
+
+    @_transparent
+    public func conjugate() -> Complex {
+        var complex = self
+        complex.formConjugate()
+        return complex
+    }
+
+    @_transparent
+    public mutating func formConjugate() {
+        imaginary.negate()
+    }
+}
+
+extension Complex where Scalar: SignedNumeric {
+
+    @_transparent
+    public mutating func negate() {
+        real.negate()
+        imaginary.negate()
+    }
+
+    @_transparent
+    public static prefix func - (complex: Complex) -> Complex {
+        var value = complex
+        value.negate()
+        return value
+    }
+}
+
+// MARK: - Complex Extensions
+
+extension Complex {
+
+    @_transparent
+    public static var i: Complex {
+        return Complex(real: .zero, imaginary: 1)
+    }
+}
+
+extension Complex {
+
+    @_transparent
+    public static var one: Complex {
+        return Complex(real: 1, imaginary: .zero)
+    }
+}
+
+extension Complex {
+
+    @inlinable @inline(__always)
+    public static prefix func + (complex: Complex) -> Complex {
+        return complex
+    }
+}
+
+// MARK: - Complex.Notation Definition
+
+extension Complex {
+
+    public enum Notation: String, Codable, Hashable {
+
+        case square
+        case trigonometric
+        case euler
+        case angle
     }
 }

--- a/Sources/Complex/ComplexArithmetic.swift
+++ b/Sources/Complex/ComplexArithmetic.swift
@@ -1,0 +1,191 @@
+//
+//  ComplexArithmetic.swift
+//  Complex
+//
+//  Copyright © 2020 SomeRandomiOSDev. All rights reserved.
+//
+
+import Foundation
+
+//swiftlint:disable shorthand_operator
+
+// MARK: - AdditiveArithmetic Protocol Conformance
+
+extension Complex: AdditiveArithmetic {
+
+    @_transparent
+    public static var zero: Complex<Scalar> {
+        return Complex<Scalar>(real: .zero, imaginary: .zero)
+    }
+
+    @_transparent
+    public static func + (lhs: Complex<Scalar>, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs.real + rhs.real, imaginary: lhs.imaginary + rhs.imaginary)
+    }
+
+    @_transparent
+    public static func += (lhs: inout Complex<Scalar>, rhs: Complex<Scalar>) {
+        lhs = lhs + rhs
+    }
+
+    @_transparent
+    public static func - (lhs: Complex<Scalar>, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs.real - rhs.real, imaginary: lhs.imaginary - rhs.imaginary)
+    }
+
+    @_transparent
+    public static func -= (lhs: inout Complex<Scalar>, rhs: Complex<Scalar>) {
+        lhs = lhs - rhs
+    }
+}
+
+// MARK: - Addition/Subtraction
+
+extension Complex {
+
+    @_transparent
+    public static func + (lhs: Complex<Scalar>, rhs: Scalar) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs.real + rhs, imaginary: lhs.imaginary)
+    }
+
+    @_transparent
+    public static func + (lhs: Scalar, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs + rhs.real, imaginary: rhs.imaginary)
+    }
+
+    @_transparent
+    public static func += (lhs: inout Complex<Scalar>, rhs: Scalar) {
+        lhs = lhs + rhs
+    }
+
+    //
+
+    @_transparent
+    public static func - (lhs: Complex<Scalar>, rhs: Scalar) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs.real - rhs, imaginary: lhs.imaginary)
+    }
+
+    @_transparent
+    public static func -= (lhs: inout Complex<Scalar>, rhs: Scalar) {
+        lhs = lhs - rhs
+    }
+}
+
+extension Complex where Scalar: SignedNumeric {
+
+    @_transparent
+    public static func - (lhs: Scalar, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs - rhs.real, imaginary: -rhs.imaginary)
+    }
+}
+
+// MARK: - Multiplication
+
+extension Complex {
+
+    @_transparent
+    public static func * (lhs: Complex<Scalar>, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        let real = (lhs.real * rhs.real) - (lhs.imaginary * rhs.imaginary)
+        let imaginary = (lhs.real * rhs.imaginary) + (lhs.imaginary * rhs.real)
+
+        return Complex<Scalar>(real: real, imaginary: imaginary)
+    }
+
+    @_transparent
+    public static func *= (lhs: inout Complex<Scalar>, rhs: Complex<Scalar>) {
+        lhs = lhs * rhs
+    }
+
+    //
+
+    @_transparent
+    public static func * (lhs: Complex<Scalar>, rhs: Scalar) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs.real * rhs, imaginary: lhs.imaginary * rhs)
+    }
+
+    @_transparent
+    public static func * (lhs: Scalar, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs * rhs.real, imaginary: lhs * rhs.imaginary)
+    }
+
+    @_transparent
+    public static func *= (lhs: inout Complex<Scalar>, rhs: Scalar) {
+        lhs = lhs * rhs
+    }
+}
+
+// MARK: - Division (BinaryInteger)
+
+extension Complex where Scalar: BinaryInteger {
+
+    @_transparent
+    public static func / (lhs: Complex<Scalar>, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        let real = (lhs.real * rhs.real + lhs.imaginary * rhs.imaginary)
+        let imaginary = (lhs.imaginary * rhs.real - lhs.real * rhs.imaginary)
+        let denominator = (rhs.real * rhs.real) + (rhs.imaginary * rhs.imaginary)
+
+        return Complex<Scalar>(real: real / denominator, imaginary: imaginary / denominator)
+    }
+
+    @_transparent
+    public static func /= (lhs: inout Complex<Scalar>, rhs: Complex<Scalar>) {
+        lhs = lhs / rhs
+    }
+
+    //
+
+    @_transparent
+    public static func / (lhs: Complex<Scalar>, rhs: Scalar) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs)
+    }
+
+    @_transparent
+    public static func /= (lhs: inout Complex<Scalar>, rhs: Scalar) {
+        lhs = lhs / rhs
+    }
+}
+
+// MARK: - Division (SignedInteger)
+
+extension Complex where Scalar: SignedInteger {
+
+    @_transparent
+    public static func / (lhs: Scalar, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs, imaginary: .zero) / rhs
+    }
+}
+
+// MARK: - Division (FloatingPoint)
+
+extension Complex where Scalar: FloatingPoint {
+
+    @_transparent
+    public static func / (lhs: Complex<Scalar>, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        let numerator = lhs * rhs.conjugate()
+        let denominator = rhs * rhs.conjugate() // Multiplying the denominator by its conjugate cancels out its imaginary component
+
+        return Complex<Scalar>(real: numerator.real / denominator.real, imaginary: numerator.imaginary / denominator.real)
+    }
+
+    @_transparent
+    public static func /= (lhs: inout Complex<Scalar>, rhs: Complex<Scalar>) {
+        lhs = lhs / rhs
+    }
+
+    //
+
+    @_transparent
+    public static func / (lhs: Complex<Scalar>, rhs: Scalar) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs)
+    }
+
+    @_transparent
+    public static func / (lhs: Scalar, rhs: Complex<Scalar>) -> Complex<Scalar> {
+        return Complex<Scalar>(real: lhs, imaginary: .zero) / rhs
+    }
+
+    @_transparent
+    public static func /= (lhs: inout Complex<Scalar>, rhs: Scalar) {
+        lhs = lhs / rhs
+    }
+}

--- a/Sources/Complex/Functions.swift
+++ b/Sources/Complex/Functions.swift
@@ -8,56 +8,56 @@
 import Foundation
 
 @_transparent
-public func csqrt<F>(_ value: F) -> Complex<F> where F: BinaryFloatingPoint {
+public func csqrt<F>(_ value: F) -> Complex<F> where F: FloatingPoint {
     let complex: Complex<F>
     if value < 0 {
-        complex = Complex(real: 0.0, imaginary: sqrt(-value))
+        complex = Complex(real: .zero, imaginary: sqrt(-value))
     } else {
-        complex = Complex(real: sqrt(value), imaginary: 0.0)
+        complex = Complex(real: sqrt(value), imaginary: .zero)
     }
 
     return complex
 }
 
 @_transparent
-public func sqrt<F>(_ value: Complex<F>) -> Complex<F> where F: BinaryFloatingPoint {
+public func sqrt<F>(_ value: Complex<F>) -> Complex<F> where F: FloatingPoint {
     //swiftlint:disable opening_brace statement_position
     let sign = { (value: F) -> F in
         let sign: F
-        if value < 0.0 { sign = -1.0 }
-        else           { sign = 1.0 }
+        if value < .zero { sign = -1 }
+        else             { sign = 1 }
         return sign
     }
     //swiftlint:enable opening_brace statement_position
 
     let modulus = value.modulus
-    let real = sqrt((value.real + modulus) * 0.5)
-    let imaginary = sign(value.imaginary) * sqrt((modulus - value.real) * 0.5)
+    let real = sqrt((value.real + modulus) / F(2))
+    let imaginary = sign(value.imaginary) * sqrt((modulus - value.real) / F(2))
 
     return Complex(real: real, imaginary: imaginary)
 }
 
 @_transparent
-public func abs<F>(_ value: Complex<F>) -> Complex<F> where F: BinaryFloatingPoint {
+public func abs<F>(_ value: Complex<F>) -> Complex<F> where F: Comparable, F: SignedNumeric {
     return Complex(real: abs(value.real), imaginary: abs(value.imaginary))
 }
 
 @_transparent
-public func min<F>(_ lhs: Complex<F>, _ rhs: Complex<F>) -> Complex<F> where F: BinaryFloatingPoint {
+public func min<F>(_ lhs: Complex<F>, _ rhs: Complex<F>) -> Complex<F> where F: Comparable {
     return Complex(real: min(lhs.real, rhs.real), imaginary: min(lhs.imaginary, rhs.imaginary))
 }
 
 @_transparent
-public func max<F>(_ lhs: Complex<F>, _ rhs: Complex<F>) -> Complex<F> where F: BinaryFloatingPoint {
+public func max<F>(_ lhs: Complex<F>, _ rhs: Complex<F>) -> Complex<F> where F: Comparable {
     return Complex(real: max(lhs.real, rhs.real), imaginary: max(lhs.imaginary, rhs.imaginary))
 }
 
 @_transparent
-public func clamp<F>(_ value: Complex<F>, _ minimum: F, _ maximum: F) -> Complex<F> where F: BinaryFloatingPoint {
+public func clamp<F>(_ value: Complex<F>, _ minimum: F, _ maximum: F) -> Complex<F> where F: Comparable {
     return Complex(real: max(minimum, min(value.real, maximum)), imaginary: max(minimum, min(value.imaginary, maximum)))
 }
 
 @_transparent
-public func clamp<F>(_ value: Complex<F>, _ minimum: Complex<F>, _ maximum: Complex<F>) -> Complex<F> where F: BinaryFloatingPoint {
+public func clamp<F>(_ value: Complex<F>, _ minimum: Complex<F>, _ maximum: Complex<F>) -> Complex<F> where F: Comparable {
     return Complex(real: max(minimum.real, min(value.real, maximum.real)), imaginary: max(minimum.imaginary, min(value.imaginary, maximum.imaginary)))
 }

--- a/Tests/ComplexTests/ComplexArithmeticTests.swift
+++ b/Tests/ComplexTests/ComplexArithmeticTests.swift
@@ -1,0 +1,365 @@
+//
+//  ComplexArithmeticTests.swift
+//  Complex
+//
+//  Copyright © 2020 SomeRandomiOSDev. All rights reserved.
+//
+
+@testable import Complex
+import Half
+import XCTest
+
+class ComplexArithmeticTests: XCTestCase {
+
+    // MARK: Test Methods
+
+    func testAdditionWithZero() {
+        testAdditionWithZero(Complex(real: Int8(1), imaginary: Int8(-4)))
+        testAdditionWithZero(Complex(real: Int16(1), imaginary: Int16(-4)))
+        testAdditionWithZero(Complex(real: Int32(1), imaginary: Int32(-4)))
+        testAdditionWithZero(Complex(real: Int64(1), imaginary: Int64(-4)))
+        testAdditionWithZero(Complex(real: Int(1), imaginary: Int(-4)))
+        testAdditionWithZero(Complex(real: UInt8(7), imaginary: UInt8(13)))
+        testAdditionWithZero(Complex(real: UInt16(7), imaginary: UInt16(13)))
+        testAdditionWithZero(Complex(real: UInt32(7), imaginary: UInt32(13)))
+        testAdditionWithZero(Complex(real: UInt64(7), imaginary: UInt64(13)))
+        testAdditionWithZero(Complex(real: UInt(7), imaginary: UInt(13)))
+        testAdditionWithZero(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testAdditionWithZero(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testAdditionWithZero(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testAdditionWithZero(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
+
+    func testSubtractionWithZero() {
+        testSubtractionWithZero(Complex(real: Int8(1), imaginary: Int8(-4)))
+        testSubtractionWithZero(Complex(real: Int16(1), imaginary: Int16(-4)))
+        testSubtractionWithZero(Complex(real: Int32(1), imaginary: Int32(-4)))
+        testSubtractionWithZero(Complex(real: Int64(1), imaginary: Int64(-4)))
+        testSubtractionWithZero(Complex(real: Int(1), imaginary: Int(-4)))
+        testSubtractionWithZero(Complex(real: UInt8(7), imaginary: UInt8(13)))
+        testSubtractionWithZero(Complex(real: UInt16(7), imaginary: UInt16(13)))
+        testSubtractionWithZero(Complex(real: UInt32(7), imaginary: UInt32(13)))
+        testSubtractionWithZero(Complex(real: UInt64(7), imaginary: UInt64(13)))
+        testSubtractionWithZero(Complex(real: UInt(7), imaginary: UInt(13)))
+        testSubtractionWithZero(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testSubtractionWithZero(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testSubtractionWithZero(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testSubtractionWithZero(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
+
+    func testMultiplicationWithZero() {
+        testMultiplicationWithZero(Complex(real: Int8(1), imaginary: Int8(-4)))
+        testMultiplicationWithZero(Complex(real: Int16(1), imaginary: Int16(-4)))
+        testMultiplicationWithZero(Complex(real: Int32(1), imaginary: Int32(-4)))
+        testMultiplicationWithZero(Complex(real: Int64(1), imaginary: Int64(-4)))
+        testMultiplicationWithZero(Complex(real: Int(1), imaginary: Int(-4)))
+        testMultiplicationWithZero(Complex(real: UInt8(7), imaginary: UInt8(13)))
+        testMultiplicationWithZero(Complex(real: UInt16(7), imaginary: UInt16(13)))
+        testMultiplicationWithZero(Complex(real: UInt32(7), imaginary: UInt32(13)))
+        testMultiplicationWithZero(Complex(real: UInt64(7), imaginary: UInt64(13)))
+        testMultiplicationWithZero(Complex(real: UInt(7), imaginary: UInt(13)))
+        testMultiplicationWithZero(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testMultiplicationWithZero(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testMultiplicationWithZero(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testMultiplicationWithZero(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
+
+    func testAddition() {
+        testAddition(Complex<Int8>(real: 1, imaginary: 2), Complex<Int8>(real: 3, imaginary: 4), Complex<Int8>(real: 4, imaginary: 6))
+        testAddition(Complex<Int16>(real: 1, imaginary: 2), Complex<Int16>(real: 3, imaginary: 4), Complex<Int16>(real: 4, imaginary: 6))
+        testAddition(Complex<Int32>(real: 1, imaginary: 2), Complex<Int32>(real: 3, imaginary: 4), Complex<Int32>(real: 4, imaginary: 6))
+        testAddition(Complex<Int64>(real: 1, imaginary: 2), Complex<Int64>(real: 3, imaginary: 4), Complex<Int64>(real: 4, imaginary: 6))
+        testAddition(Complex<Int>(real: 1, imaginary: 2), Complex<Int>(real: 3, imaginary: 4), Complex<Int>(real: 4, imaginary: 6))
+        testAddition(Complex<UInt8>(real: 1, imaginary: 2), Complex<UInt8>(real: 3, imaginary: 4), Complex<UInt8>(real: 4, imaginary: 6))
+        testAddition(Complex<UInt16>(real: 1, imaginary: 2), Complex<UInt16>(real: 3, imaginary: 4), Complex<UInt16>(real: 4, imaginary: 6))
+        testAddition(Complex<UInt32>(real: 1, imaginary: 2), Complex<UInt32>(real: 3, imaginary: 4), Complex<UInt32>(real: 4, imaginary: 6))
+        testAddition(Complex<UInt64>(real: 1, imaginary: 2), Complex<UInt64>(real: 3, imaginary: 4), Complex<UInt64>(real: 4, imaginary: 6))
+        testAddition(Complex<UInt>(real: 1, imaginary: 2), Complex<UInt>(real: 3, imaginary: 4), Complex<UInt>(real: 4, imaginary: 6))
+        testAddition(Complex<Half>(real: 1.0, imaginary: 2.0), Complex<Half>(real: 3.0, imaginary: 4.0), Complex<Half>(real: 4.0, imaginary: 6.0))
+        testAddition(Complex<Float>(real: 1.0, imaginary: 2.0), Complex<Float>(real: 3.0, imaginary: 4.0), Complex<Float>(real: 4.0, imaginary: 6.0))
+        testAddition(Complex<Double>(real: 1.0, imaginary: 2.0), Complex<Double>(real: 3.0, imaginary: 4.0), Complex<Double>(real: 4.0, imaginary: 6.0))
+        testAddition(Complex<Float80>(real: 1.0, imaginary: 2.0), Complex<Float80>(real: 3.0, imaginary: 4.0), Complex<Float80>(real: 4.0, imaginary: 6.0))
+
+        testAddition(Complex<Int8>(real: 1, imaginary: 2), 3, Complex<Int8>(real: 4, imaginary: 2))
+        testAddition(Complex<Int16>(real: 1, imaginary: 2), 3, Complex<Int16>(real: 4, imaginary: 2))
+        testAddition(Complex<Int32>(real: 1, imaginary: 2), 3, Complex<Int32>(real: 4, imaginary: 2))
+        testAddition(Complex<Int64>(real: 1, imaginary: 2), 3, Complex<Int64>(real: 4, imaginary: 2))
+        testAddition(Complex<Int>(real: 1, imaginary: 2), 3, Complex<Int>(real: 4, imaginary: 2))
+        testAddition(Complex<UInt8>(real: 1, imaginary: 2), 3, Complex<UInt8>(real: 4, imaginary: 2))
+        testAddition(Complex<UInt16>(real: 1, imaginary: 2), 3, Complex<UInt16>(real: 4, imaginary: 2))
+        testAddition(Complex<UInt32>(real: 1, imaginary: 2), 3, Complex<UInt32>(real: 4, imaginary: 2))
+        testAddition(Complex<UInt64>(real: 1, imaginary: 2), 3, Complex<UInt64>(real: 4, imaginary: 2))
+        testAddition(Complex<UInt>(real: 1, imaginary: 2), 3, Complex<UInt>(real: 4, imaginary: 2))
+        testAddition(Complex<Half>(real: 1.0, imaginary: 2.0), 3.0, Complex<Half>(real: 4.0, imaginary: 2.0))
+        testAddition(Complex<Float>(real: 1.0, imaginary: 2.0), 3.0, Complex<Float>(real: 4.0, imaginary: 2.0))
+        testAddition(Complex<Double>(real: 1.0, imaginary: 2.0), 3.0, Complex<Double>(real: 4.0, imaginary: 2.0))
+        testAddition(Complex<Float80>(real: 1.0, imaginary: 2.0), 3.0, Complex<Float80>(real: 4.0, imaginary: 2.0))
+    }
+
+    func testSubtraction() {
+        testSubtraction(Complex<Int8>(real: 3, imaginary: 4), Complex<Int8>(real: 1, imaginary: 2), Complex<Int8>(real: 2, imaginary: 2))
+        testSubtraction(Complex<Int16>(real: 3, imaginary: 4), Complex<Int16>(real: 1, imaginary: 2), Complex<Int16>(real: 2, imaginary: 2))
+        testSubtraction(Complex<Int32>(real: 3, imaginary: 4), Complex<Int32>(real: 1, imaginary: 2), Complex<Int32>(real: 2, imaginary: 2))
+        testSubtraction(Complex<Int64>(real: 3, imaginary: 4), Complex<Int64>(real: 1, imaginary: 2), Complex<Int64>(real: 2, imaginary: 2))
+        testSubtraction(Complex<Int>(real: 3, imaginary: 4), Complex<Int>(real: 1, imaginary: 2), Complex<Int>(real: 2, imaginary: 2))
+        testSubtraction(Complex<UInt8>(real: 3, imaginary: 4), Complex<UInt8>(real: 1, imaginary: 2), Complex<UInt8>(real: 2, imaginary: 2))
+        testSubtraction(Complex<UInt16>(real: 3, imaginary: 4), Complex<UInt16>(real: 1, imaginary: 2), Complex<UInt16>(real: 2, imaginary: 2))
+        testSubtraction(Complex<UInt32>(real: 3, imaginary: 4), Complex<UInt32>(real: 1, imaginary: 2), Complex<UInt32>(real: 2, imaginary: 2))
+        testSubtraction(Complex<UInt64>(real: 3, imaginary: 4), Complex<UInt64>(real: 1, imaginary: 2), Complex<UInt64>(real: 2, imaginary: 2))
+        testSubtraction(Complex<UInt>(real: 3, imaginary: 4), Complex<UInt>(real: 1, imaginary: 2), Complex<UInt>(real: 2, imaginary: 2))
+        testSubtraction(Complex<Half>(real: 3.0, imaginary: 4.0), Complex<Half>(real: 1.0, imaginary: 2.0), Complex<Half>(real: 2.0, imaginary: 2.0))
+        testSubtraction(Complex<Float>(real: 3.0, imaginary: 4.0), Complex<Float>(real: 1.0, imaginary: 2.0), Complex<Float>(real: 2.0, imaginary: 2.0))
+        testSubtraction(Complex<Double>(real: 3.0, imaginary: 4.0), Complex<Double>(real: 1.0, imaginary: 2.0), Complex<Double>(real: 2.0, imaginary: 2.0))
+        testSubtraction(Complex<Float80>(real: 3.0, imaginary: 4.0), Complex<Float80>(real: 1.0, imaginary: 2.0), Complex<Float80>(real: 2.0, imaginary: 2.0))
+
+        testSubtraction(Complex<Int8>(real: 3, imaginary: 4), 1, Complex<Int8>(real: 2, imaginary: 4))
+        testSubtraction(Complex<Int16>(real: 3, imaginary: 4), 1, Complex<Int16>(real: 2, imaginary: 4))
+        testSubtraction(Complex<Int32>(real: 3, imaginary: 4), 1, Complex<Int32>(real: 2, imaginary: 4))
+        testSubtraction(Complex<Int64>(real: 3, imaginary: 4), 1, Complex<Int64>(real: 2, imaginary: 4))
+        testSubtraction(Complex<Int>(real: 3, imaginary: 4), 1, Complex<Int>(real: 2, imaginary: 4))
+        testSubtraction(Complex<UInt8>(real: 3, imaginary: 4), 1, Complex<UInt8>(real: 2, imaginary: 4))
+        testSubtraction(Complex<UInt16>(real: 3, imaginary: 4), 1, Complex<UInt16>(real: 2, imaginary: 4))
+        testSubtraction(Complex<UInt32>(real: 3, imaginary: 4), 1, Complex<UInt32>(real: 2, imaginary: 4))
+        testSubtraction(Complex<UInt64>(real: 3, imaginary: 4), 1, Complex<UInt64>(real: 2, imaginary: 4))
+        testSubtraction(Complex<UInt>(real: 3, imaginary: 4), 1, Complex<UInt>(real: 2, imaginary: 4))
+        testSubtraction(Complex<Half>(real: 3.0, imaginary: 4.0), 1.0, Complex<Half>(real: 2.0, imaginary: 4.0))
+        testSubtraction(Complex<Float>(real: 3.0, imaginary: 4.0), 1.0, Complex<Float>(real: 2.0, imaginary: 4.0))
+        testSubtraction(Complex<Double>(real: 3.0, imaginary: 4.0), 1.0, Complex<Double>(real: 2.0, imaginary: 4.0))
+        testSubtraction(Complex<Float80>(real: 3.0, imaginary: 4.0), 1.0, Complex<Float80>(real: 2.0, imaginary: 4.0))
+    }
+
+    func testMultiplication() {
+        testMultiplication(Complex<Int8>(real: 3, imaginary: 4), Complex<Int8>(real: 1, imaginary: 2), Complex<Int8>(real: -5, imaginary: 10))
+        testMultiplication(Complex<Int16>(real: 3, imaginary: 4), Complex<Int16>(real: 1, imaginary: 2), Complex<Int16>(real: -5, imaginary: 10))
+        testMultiplication(Complex<Int32>(real: 3, imaginary: 4), Complex<Int32>(real: 1, imaginary: 2), Complex<Int32>(real: -5, imaginary: 10))
+        testMultiplication(Complex<Int64>(real: 3, imaginary: 4), Complex<Int64>(real: 1, imaginary: 2), Complex<Int64>(real: -5, imaginary: 10))
+        testMultiplication(Complex<Int>(real: 3, imaginary: 4), Complex<Int>(real: 1, imaginary: 2), Complex<Int>(real: -5, imaginary: 10))
+        testMultiplication(Complex<UInt8>(real: 4, imaginary: 3), Complex<UInt8>(real: 2, imaginary: 1), Complex<UInt8>(real: 5, imaginary: 10))
+        testMultiplication(Complex<UInt16>(real: 4, imaginary: 3), Complex<UInt16>(real: 2, imaginary: 1), Complex<UInt16>(real: 5, imaginary: 10))
+        testMultiplication(Complex<UInt32>(real: 4, imaginary: 3), Complex<UInt32>(real: 2, imaginary: 1), Complex<UInt32>(real: 5, imaginary: 10))
+        testMultiplication(Complex<UInt64>(real: 4, imaginary: 3), Complex<UInt64>(real: 2, imaginary: 1), Complex<UInt64>(real: 5, imaginary: 10))
+        testMultiplication(Complex<UInt>(real: 4, imaginary: 3), Complex<UInt>(real: 2, imaginary: 1), Complex<UInt>(real: 5, imaginary: 10))
+        testMultiplication(Complex<Half>(real: 3.0, imaginary: 4.0), Complex<Half>(real: 1.0, imaginary: 2.0), Complex<Half>(real: -5.0, imaginary: 10.0))
+        testMultiplication(Complex<Float>(real: 3.0, imaginary: 4.0), Complex<Float>(real: 1.0, imaginary: 2.0), Complex<Float>(real: -5.0, imaginary: 10.0))
+        testMultiplication(Complex<Double>(real: 3.0, imaginary: 4.0), Complex<Double>(real: 1.0, imaginary: 2.0), Complex<Double>(real: -5.0, imaginary: 10.0))
+        testMultiplication(Complex<Float80>(real: 3.0, imaginary: 4.0), Complex<Float80>(real: 1.0, imaginary: 2.0), Complex<Float80>(real: -5.0, imaginary: 10.0))
+
+        testMultiplication(Complex<Int8>(real: 3, imaginary: 4), 2)
+        testMultiplication(Complex<Int16>(real: 3, imaginary: 4), 2)
+        testMultiplication(Complex<Int32>(real: 3, imaginary: 4), 2)
+        testMultiplication(Complex<Int64>(real: 3, imaginary: 4), 2)
+        testMultiplication(Complex<Int>(real: 3, imaginary: 4), 2)
+        testMultiplication(Complex<UInt8>(real: 4, imaginary: 3), 2)
+        testMultiplication(Complex<UInt16>(real: 4, imaginary: 3), 2)
+        testMultiplication(Complex<UInt32>(real: 4, imaginary: 3), 2)
+        testMultiplication(Complex<UInt64>(real: 4, imaginary: 3), 2)
+        testMultiplication(Complex<UInt>(real: 4, imaginary: 3), 2)
+        testMultiplication(Complex<Half>(real: 3.0, imaginary: 4.0), 2.0)
+        testMultiplication(Complex<Float>(real: 3.0, imaginary: 4.0), 2.0)
+        testMultiplication(Complex<Double>(real: 3.0, imaginary: 4.0), 2.0)
+        testMultiplication(Complex<Float80>(real: 3.0, imaginary: 4.0), 2.0)
+    }
+
+    func testDivision() {
+        testDivision(Complex<Int8>(real: 3, imaginary: 4), Complex<Int8>(real: 2, imaginary: 1), Complex<Int8>(real: 2, imaginary: 1))
+        testDivision(Complex<Int16>(real: 3, imaginary: 4), Complex<Int16>(real: 2, imaginary: 1), Complex<Int16>(real: 2, imaginary: 1))
+        testDivision(Complex<Int32>(real: 3, imaginary: 4), Complex<Int32>(real: 2, imaginary: 1), Complex<Int32>(real: 2, imaginary: 1))
+        testDivision(Complex<Int64>(real: 3, imaginary: 4), Complex<Int64>(real: 2, imaginary: 1), Complex<Int64>(real: 2, imaginary: 1))
+        testDivision(Complex<Int>(real: 3, imaginary: 4), Complex<Int>(real: 2, imaginary: 1), Complex<Int>(real: 2, imaginary: 1))
+        testDivision(Complex<UInt8>(real: 3, imaginary: 4), Complex<UInt8>(real: 2, imaginary: 1), Complex<UInt8>(real: 2, imaginary: 1))
+        testDivision(Complex<UInt16>(real: 3, imaginary: 4), Complex<UInt16>(real: 2, imaginary: 1), Complex<UInt16>(real: 2, imaginary: 1))
+        testDivision(Complex<UInt32>(real: 3, imaginary: 4), Complex<UInt32>(real: 2, imaginary: 1), Complex<UInt32>(real: 2, imaginary: 1))
+        testDivision(Complex<UInt64>(real: 3, imaginary: 4), Complex<UInt64>(real: 2, imaginary: 1), Complex<UInt64>(real: 2, imaginary: 1))
+        testDivision(Complex<UInt>(real: 3, imaginary: 4), Complex<UInt>(real: 2, imaginary: 1), Complex<UInt>(real: 2, imaginary: 1))
+        testDivision(Complex<Half>(real: 3.0, imaginary: 4.0), Complex<Half>(real: 1.0, imaginary: 2.0), Complex<Half>(real: 11.0 / 5.0, imaginary: -0.4))
+        testDivision(Complex<Float>(real: 3.0, imaginary: 4.0), Complex<Float>(real: 1.0, imaginary: 2.0), Complex<Float>(real: 11.0 / 5.0, imaginary: -0.4))
+        testDivision(Complex<Double>(real: 3.0, imaginary: 4.0), Complex<Double>(real: 1.0, imaginary: 2.0), Complex<Double>(real: 11.0 / 5.0, imaginary: -0.4))
+        testDivision(Complex<Float80>(real: 3.0, imaginary: 4.0), Complex<Float80>(real: 1.0, imaginary: 2.0), Complex<Float80>(real: 11.0 / 5.0, imaginary: -0.4))
+
+        testDivision(Complex<Int8>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<Int16>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<Int32>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<Int64>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<Int>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<UInt8>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<UInt16>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<UInt32>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<UInt64>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<UInt>(real: 3, imaginary: 4), 2)
+        testDivision(Complex<Half>(real: 3.0, imaginary: 4.0), 2.0)
+        testDivision(Complex<Float>(real: 3.0, imaginary: 4.0), 2.0)
+        testDivision(Complex<Double>(real: 3.0, imaginary: 4.0), 2.0)
+        testDivision(Complex<Float80>(real: 3.0, imaginary: 4.0), 2.0)
+    }
+
+    // MARK: Private Methods
+
+    private func testAdditionWithZero<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(complex, complex + .zero, file: file, line: line)
+        XCTAssertEqual(complex, complex + Scalar.zero, file: file, line: line)
+        XCTAssertEqual(complex, Scalar.zero + complex, file: file, line: line)
+
+        var result = complex
+        result += .zero
+        XCTAssertEqual(result, complex, file: file, line: line)
+
+        result = complex
+        XCTAssertEqual(result, complex, file: file, line: line)
+
+        result = complex
+        result += Scalar.zero
+        XCTAssertEqual(result, complex, file: file, line: line)
+    }
+
+    private func testSubtractionWithZero<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(complex, complex - .zero, file: file, line: line)
+        XCTAssertEqual(complex, complex - Scalar.zero, file: file, line: line)
+
+        var result = complex
+        result -= .zero
+        XCTAssertEqual(result, complex, file: file, line: line)
+
+        result = complex
+        result -= Scalar.zero
+        XCTAssertEqual(result, complex, file: file, line: line)
+    }
+
+    private func testMultiplicationWithZero<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(.zero, complex * .zero, file: file, line: line)
+        XCTAssertEqual(.zero, complex * Scalar.zero, file: file, line: line)
+        XCTAssertEqual(.zero, Scalar.zero * complex, file: file, line: line)
+
+        var result = complex
+        result *= .zero
+        XCTAssertEqual(result, .zero, file: file, line: line)
+
+        result = complex
+        result *= Scalar.zero
+        XCTAssertEqual(result, .zero, file: file, line: line)
+    }
+
+    private func testAddition<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(lhs + rhs, result, file: file, line: line)
+        XCTAssertEqual(rhs + lhs, result, file: file, line: line)
+
+        var complex = lhs
+        complex += rhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+
+        complex = rhs
+        complex += lhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+    }
+
+    private func testAddition<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(lhs + rhs, result, file: file, line: line)
+        XCTAssertEqual(rhs + lhs, result, file: file, line: line)
+
+        var complex = lhs
+        complex += rhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+    }
+
+    private func testSubtraction<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(lhs - rhs, result, file: file, line: line)
+
+        var complex = lhs
+        complex -= rhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+    }
+
+    private func testSubtraction<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
+        XCTAssertEqual(lhs - rhs, result, file: file, line: line)
+        XCTAssertEqual(rhs - lhs, -result, file: file, line: line)
+
+        var complex = lhs
+        complex -= rhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+
+        complex = rhs
+        complex -= lhs
+        XCTAssertEqual(complex, -result, file: file, line: line)
+    }
+
+    private func testSubtraction<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(lhs - rhs, result, file: file, line: line)
+
+        var complex = lhs
+        complex -= rhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+    }
+
+    private func testSubtraction<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
+        XCTAssertEqual(lhs - rhs, result, file: file, line: line)
+        XCTAssertEqual(rhs - lhs, -result, file: file, line: line)
+
+        var complex = lhs
+        complex -= rhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+    }
+
+    private func testMultiplication<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(lhs * rhs, result, file: file, line: line)
+        XCTAssertEqual(rhs * lhs, result, file: file, line: line)
+
+        var complex = lhs
+        complex *= rhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+
+        complex = rhs
+        complex *= lhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+    }
+
+    private func testMultiplication<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, file: StaticString = #file, line: UInt = #line) {
+        let result = Complex(real: lhs.real * rhs, imaginary: lhs.imaginary * rhs)
+        XCTAssertEqual(lhs * rhs, result, file: file, line: line)
+        XCTAssertEqual(rhs * lhs, result, file: file, line: line)
+
+        var complex = lhs
+        complex *= rhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+    }
+
+    private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryInteger {
+        XCTAssertEqual(lhs / rhs, result, file: file, line: line)
+
+        var complex = lhs
+        complex /= rhs
+        XCTAssertEqual(complex, result, file: file, line: line)
+    }
+
+    private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint {
+        XCTAssertTrue((lhs / rhs - result).modulus < 0.0001, file: file, line: line)
+
+        var complex = lhs
+        complex /= rhs
+        XCTAssertTrue((complex - result).modulus < 0.0001, file: file, line: line)
+    }
+
+    private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryInteger {
+        XCTAssertEqual(lhs / rhs, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+
+        var complex = lhs
+        complex /= rhs
+        XCTAssertEqual(complex, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+    }
+
+    private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: SignedInteger {
+        XCTAssertEqual(lhs / rhs, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+        XCTAssertEqual(rhs / lhs, (Complex(real: rhs, imaginary: 0) / lhs), file: file, line: line)
+
+        var complex = lhs
+        complex /= rhs
+        XCTAssertEqual(complex, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+    }
+
+    private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint {
+        XCTAssertEqual(lhs / rhs, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+        XCTAssertEqual(rhs / lhs, (Complex(real: rhs, imaginary: 0) / lhs), file: file, line: line)
+
+        var complex = lhs
+        complex /= rhs
+        XCTAssertEqual(complex, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+    }
+}

--- a/Tests/ComplexTests/ComplexTests.swift
+++ b/Tests/ComplexTests/ComplexTests.swift
@@ -13,172 +13,148 @@ class ComplexTests: XCTestCase {
 
     // MARK: Test Methods
 
-    func testComplexInitialization() {
-        do {
-            var complex = Complex<Half>(real: -1.0, imaginary: 2.5)
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
+    func testInitialization() {
+        testInitialization(real: Int8(1), imaginary: Int8(-4))
+        testInitialization(real: Int16(1), imaginary: Int16(-4))
+        testInitialization(real: Int32(1), imaginary: Int32(-4))
+        testInitialization(real: Int64(1), imaginary: Int64(-4))
+        testInitialization(real: UInt8(7), imaginary: UInt8(13))
+        testInitialization(real: UInt16(7), imaginary: UInt16(13))
+        testInitialization(real: UInt32(7), imaginary: UInt32(13))
+        testInitialization(real: UInt64(7), imaginary: UInt64(13))
+        testInitialization(real: Half(1.2), imaginary: Half(-7.4))
+        testInitialization(real: Float(-0.123), imaginary: Float(3.0))
+        testInitialization(real: Double(8.9), imaginary: Double(10.8))
+        testInitialization(real: Float80(11.1), imaginary: Float80(-0.9))
+    }
 
-            complex = Complex<Half>(real: Float(-1.0), imaginary: Float(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
+    func testRandomFactoryMethods() {
+        testRandomFactoryMethods(lowerBound: Int8(-4), upperBound: Int8(8))
+        testRandomFactoryMethods(lowerBound: Int16(-4), upperBound: Int16(8))
+        testRandomFactoryMethods(lowerBound: Int32(-4), upperBound: Int32(8))
+        testRandomFactoryMethods(lowerBound: Int64(-4), upperBound: Int64(8))
+        testRandomFactoryMethods(lowerBound: UInt8(7), upperBound: UInt8(43))
+        testRandomFactoryMethods(lowerBound: UInt16(7), upperBound: UInt16(43))
+        testRandomFactoryMethods(lowerBound: UInt32(7), upperBound: UInt32(43))
+        testRandomFactoryMethods(lowerBound: UInt64(7), upperBound: UInt64(43))
+        testRandomFactoryMethods(lowerBound: Half(-1.2), upperBound: Half(7.4))
+        testRandomFactoryMethods(lowerBound: Float(-0.123), upperBound: Float(3.0))
+        testRandomFactoryMethods(lowerBound: Double(8.9), upperBound: Double(10.8))
+        testRandomFactoryMethods(lowerBound: Float80(-11.1), upperBound: Float80(0.9))
+    }
 
-            complex = Complex<Half>(real: Double(-1.0), imaginary: Double(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
+    func testDescriptionMethods() throws {
+        try testDescriptionMethods(Complex(real: Int8(1), imaginary: Int8(-4)))
+        try testDescriptionMethods(Complex(real: Int16(1), imaginary: Int16(-4)))
+        try testDescriptionMethods(Complex(real: Int32(1), imaginary: Int32(-4)))
+        try testDescriptionMethods(Complex(real: Int64(1), imaginary: Int64(-4)))
+        try testDescriptionMethods(Complex(real: UInt8(7), imaginary: UInt8(13)))
+        try testDescriptionMethods(Complex(real: UInt16(7), imaginary: UInt16(13)))
+        try testDescriptionMethods(Complex(real: UInt32(7), imaginary: UInt32(13)))
+        try testDescriptionMethods(Complex(real: UInt64(7), imaginary: UInt64(13)))
+        try testDescriptionMethods(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        try testDescriptionMethods(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        try testDescriptionMethods(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        try testDescriptionMethods(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-            complex = Complex<Half>(real: Float80(-1.0), imaginary: Float80(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+    func testHashing() {
+        testHashing(Complex(real: Int8(1), imaginary: Int8(-4)))
+        testHashing(Complex(real: Int16(1), imaginary: Int16(-4)))
+        testHashing(Complex(real: Int32(1), imaginary: Int32(-4)))
+        testHashing(Complex(real: Int64(1), imaginary: Int64(-4)))
+        testHashing(Complex(real: UInt8(7), imaginary: UInt8(13)))
+        testHashing(Complex(real: UInt16(7), imaginary: UInt16(13)))
+        testHashing(Complex(real: UInt32(7), imaginary: UInt32(13)))
+        testHashing(Complex(real: UInt64(7), imaginary: UInt64(13)))
+        testHashing(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testHashing(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testHashing(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testHashing(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
 
-            complex = Complex<Half>(real: Int(-4), imaginary: Int(67))
-            XCTAssertEqual(complex.real, -4.0)
-            XCTAssertEqual(complex.imaginary, 67.0)
+    func testRounding() {
+        testRounding(Complex<Half>(real: 1.5, imaginary: -4.5))
+        testRounding(Complex<Float>(real: 1.5, imaginary: -4.5))
+        testRounding(Complex<Double>(real: 1.5, imaginary: -4.5))
+        testRounding(Complex<Float80>(real: 1.5, imaginary: -4.5))
+    }
 
-            complex = Complex<Half>(Complex(real: 9.0, imaginary: 4.0))
-            XCTAssertEqual(complex.real, 9.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
+    func testConjugateMethods() {
+        testConjugateMethods(Complex(real: Int8(1), imaginary: Int8(-4)))
+        testConjugateMethods(Complex(real: Int16(1), imaginary: Int16(-4)))
+        testConjugateMethods(Complex(real: Int32(1), imaginary: Int32(-4)))
+        testConjugateMethods(Complex(real: Int64(1), imaginary: Int64(-4)))
+        testConjugateMethods(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testConjugateMethods(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testConjugateMethods(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testConjugateMethods(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
 
-            complex = []
-            XCTAssertEqual(complex.real, 0.0)
-            XCTAssertEqual(complex.imaginary, 0.0)
+    func testNegationMethods() {
+        testNegationMethods(Complex(real: Int8(1), imaginary: Int8(-4)))
+        testNegationMethods(Complex(real: Int16(1), imaginary: Int16(-4)))
+        testNegationMethods(Complex(real: Int32(1), imaginary: Int32(-4)))
+        testNegationMethods(Complex(real: Int64(1), imaginary: Int64(-4)))
+        testNegationMethods(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testNegationMethods(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testNegationMethods(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testNegationMethods(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
 
-            complex = [-1.0]
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 0.0)
+    func testMultiplyByOne() {
+        testMultiplyByOne(Complex(real: Int8(1), imaginary: Int8(-4)))
+        testMultiplyByOne(Complex(real: Int16(1), imaginary: Int16(-4)))
+        testMultiplyByOne(Complex(real: Int32(1), imaginary: Int32(-4)))
+        testMultiplyByOne(Complex(real: Int64(1), imaginary: Int64(-4)))
+        testMultiplyByOne(Complex(real: UInt8(7), imaginary: UInt8(13)))
+        testMultiplyByOne(Complex(real: UInt16(7), imaginary: UInt16(13)))
+        testMultiplyByOne(Complex(real: UInt32(7), imaginary: UInt32(13)))
+        testMultiplyByOne(Complex(real: UInt64(7), imaginary: UInt64(13)))
+        testMultiplyByOne(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testMultiplyByOne(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testMultiplyByOne(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testMultiplyByOne(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
 
-            complex = [-1.0, 2.5]
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-        }
-        do {
-            var complex = Complex<Float>(real: -1.0, imaginary: 2.5)
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
+    func testMultiplyByI() {
+        testMultiplyByI(Complex(real: Int8(1), imaginary: Int8(-4)))
+        testMultiplyByI(Complex(real: Int16(1), imaginary: Int16(-4)))
+        testMultiplyByI(Complex(real: Int32(1), imaginary: Int32(-4)))
+        testMultiplyByI(Complex(real: Int64(1), imaginary: Int64(-4)))
+        testMultiplyByI(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testMultiplyByI(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testMultiplyByI(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testMultiplyByI(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
 
-            complex = Complex<Float>(real: Half(-1.0), imaginary: Half(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
+    func testPlusPrefixOperator() {
+        testPlusPrefixOperator(Complex(real: Int8(1), imaginary: Int8(-4)))
+        testPlusPrefixOperator(Complex(real: Int16(1), imaginary: Int16(-4)))
+        testPlusPrefixOperator(Complex(real: Int32(1), imaginary: Int32(-4)))
+        testPlusPrefixOperator(Complex(real: Int64(1), imaginary: Int64(-4)))
+        testPlusPrefixOperator(Complex(real: UInt8(7), imaginary: UInt8(13)))
+        testPlusPrefixOperator(Complex(real: UInt16(7), imaginary: UInt16(13)))
+        testPlusPrefixOperator(Complex(real: UInt32(7), imaginary: UInt32(13)))
+        testPlusPrefixOperator(Complex(real: UInt64(7), imaginary: UInt64(13)))
+        testPlusPrefixOperator(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testPlusPrefixOperator(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testPlusPrefixOperator(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testPlusPrefixOperator(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
+    }
 
-            complex = Complex<Float>(real: Double(-1.0), imaginary: Double(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-            complex = Complex<Float>(real: Float80(-1.0), imaginary: Float80(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-
-            complex = Complex<Float>(real: Int(-4), imaginary: Int(67))
-            XCTAssertEqual(complex.real, -4.0)
-            XCTAssertEqual(complex.imaginary, 67.0)
-
-            complex = Complex<Float>(Complex(real: 9.0, imaginary: 4.0))
-            XCTAssertEqual(complex.real, 9.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = []
-            XCTAssertEqual(complex.real, 0.0)
-            XCTAssertEqual(complex.imaginary, 0.0)
-
-            complex = [-1.0]
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 0.0)
-
-            complex = [-1.0, 2.5]
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-        }
-        do {
-            var complex = Complex<Double>(real: -1.0, imaginary: 2.5)
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-
-            complex = Complex<Double>(real: Half(-1.0), imaginary: Half(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-
-            complex = Complex<Double>(real: Float(-1.0), imaginary: Float(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-            complex = Complex<Double>(real: Float80(-1.0), imaginary: Float80(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-
-            complex = Complex<Double>(real: Int(-4), imaginary: Int(67))
-            XCTAssertEqual(complex.real, -4.0)
-            XCTAssertEqual(complex.imaginary, 67.0)
-
-            complex = Complex<Double>(Complex(real: 9.0, imaginary: 4.0))
-            XCTAssertEqual(complex.real, 9.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = []
-            XCTAssertEqual(complex.real, 0.0)
-            XCTAssertEqual(complex.imaginary, 0.0)
-
-            complex = [-1.0]
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 0.0)
-
-            complex = [-1.0, 2.5]
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-        }
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        do {
-            var complex = Complex<Float80>(real: -1.0, imaginary: 2.5)
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-
-            complex = Complex<Float80>(real: Half(-1.0), imaginary: Half(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-
-            complex = Complex<Float80>(real: Float(-1.0), imaginary: Float(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-
-            complex = Complex<Float80>(real: Double(-1.0), imaginary: Double(2.5))
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-
-            complex = Complex<Float80>(real: Int(-4), imaginary: Int(67))
-            XCTAssertEqual(complex.real, -4.0)
-            XCTAssertEqual(complex.imaginary, 67.0)
-
-            complex = Complex<Float80>(Complex(real: 9.0, imaginary: 4.0))
-            XCTAssertEqual(complex.real, 9.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = []
-            XCTAssertEqual(complex.real, 0.0)
-            XCTAssertEqual(complex.imaginary, 0.0)
-
-            complex = [-1.0]
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 0.0)
-
-            complex = [-1.0, 2.5]
-            XCTAssertEqual(complex.real, -1.0)
-            XCTAssertEqual(complex.imaginary, 2.5)
-        }
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+    func testPolarComponents() {
+        testPolarComponents(Complex(real: Half(1.2), imaginary: Half(-7.4)))
+        testPolarComponents(Complex(real: Float(-0.123), imaginary: Float(3.0)))
+        testPolarComponents(Complex(real: Double(8.9), imaginary: Double(10.8)))
+        testPolarComponents(Complex(real: Float80(11.1), imaginary: Float80(-0.9)))
     }
 
     func testAdditiveArithmeticProtocolRequirements() {
         XCTAssertEqual(Complex<Half>.zero, Complex(real: 0.0, imaginary: 0.0))
         XCTAssertEqual(Complex<Float>.zero, Complex(real: 0.0, imaginary: 0.0))
         XCTAssertEqual(Complex<Double>.zero, Complex(real: 0.0, imaginary: 0.0))
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
         XCTAssertEqual(Complex<Float80>.zero, Complex(real: 0.0, imaginary: 0.0))
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
         do {
             let lhs = Complex<Half>(real: 1.0, imaginary: 2.0)
@@ -231,7 +207,6 @@ class ComplexTests: XCTestCase {
             XCTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
             XCTAssertEqual(value, lhs - rhs)
         }
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
         do {
             let lhs = Complex<Float80>(real: 1.0, imaginary: 2.0)
             let rhs = Complex<Float80>(real: 3.0, imaginary: 4.0)
@@ -249,624 +224,262 @@ class ComplexTests: XCTestCase {
             XCTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
             XCTAssertEqual(value, lhs - rhs)
         }
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     }
 
-    func testCustomStrings() {
-        let half = Complex<Half>(real: 1.0, imaginary: 2.0)
-        _ = half.description
-        _ = half.debugDescription
-        _ = half.string(withNotation: .square)
-        _ = half.string(withNotation: .trigonometric)
-        _ = half.string(withNotation: .euler)
-        _ = half.string(withNotation: .angle)
+    // MARK: Private Methods
 
-        let float = Complex<Float>(real: 1.0, imaginary: 2.0)
-        _ = float.description
-        _ = float.debugDescription
-        _ = float.string(withNotation: .square)
-        _ = float.string(withNotation: .trigonometric)
-        _ = float.string(withNotation: .euler)
-        _ = float.string(withNotation: .angle)
+    private func testInitialization<Scalar>(real: Scalar, imaginary: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryInteger {
+        let complex0 = Complex<Scalar>()
+        XCTAssertEqual(complex0.real, 0, file: file, line: line)
+        XCTAssertEqual(complex0.imaginary, 0, file: file, line: line)
 
-        let double = Complex<Double>(real: 1.0, imaginary: 2.0)
-        _ = double.description
-        _ = double.debugDescription
-        _ = double.string(withNotation: .square)
-        _ = double.string(withNotation: .trigonometric)
-        _ = double.string(withNotation: .euler)
-        _ = double.string(withNotation: .angle)
+        let complex1 = Complex<Scalar>(real: real, imaginary: imaginary)
+        XCTAssertEqual(complex1.real, real, file: file, line: line)
+        XCTAssertEqual(complex1.imaginary, imaginary, file: file, line: line)
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        let float80 = Complex<Float80>(real: 1.0, imaginary: 2.0)
-        _ = float80.description
-        _ = float80.debugDescription
-        _ = float80.string(withNotation: .square)
-        _ = float80.string(withNotation: .trigonometric)
-        _ = float80.string(withNotation: .euler)
-        _ = float80.string(withNotation: .angle)
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+        let complex2 = Complex<Scalar>(complex1)
+        XCTAssertEqual(complex2.real, real, file: file, line: line)
+        XCTAssertEqual(complex2.imaginary, imaginary, file: file, line: line)
+
+        let complex3 = Complex<Int64>(real: real, imaginary: imaginary)
+        XCTAssertEqual(complex3.real, Int64(real), file: file, line: line)
+        XCTAssertEqual(complex3.imaginary, Int64(imaginary), file: file, line: line)
+
+        let complex4 = Complex<Int64>(complex1)
+        XCTAssertEqual(complex4.real, Int64(real), file: file, line: line)
+        XCTAssertEqual(complex4.imaginary, Int64(imaginary), file: file, line: line)
+
+        let complex5 = Complex<Float80>(real: real, imaginary: imaginary)
+        XCTAssertEqual(complex5.real, Float80(real), file: file, line: line)
+        XCTAssertEqual(complex5.imaginary, Float80(imaginary), file: file, line: line)
+
+        let complex6 = Complex<Float80>(complex1)
+        XCTAssertEqual(complex6.real, Float80(real), file: file, line: line)
+        XCTAssertEqual(complex6.imaginary, Float80(imaginary), file: file, line: line)
+
+        let complex7: Complex<Scalar> = []
+        XCTAssertEqual(complex7.real, 0, file: file, line: line)
+        XCTAssertEqual(complex7.imaginary, 0, file: file, line: line)
+
+        let complex8: Complex<Scalar> = [real]
+        XCTAssertEqual(complex8.real, real, file: file, line: line)
+        XCTAssertEqual(complex8.imaginary, 0, file: file, line: line)
+
+        let complex9: Complex<Scalar> = [real, imaginary]
+        XCTAssertEqual(complex9.real, real, file: file, line: line)
+        XCTAssertEqual(complex9.imaginary, imaginary, file: file, line: line)
     }
 
-    func testHashing() {
-        let half = Complex<Half>(real: 1.0, imaginary: 2.0)
+    private func testInitialization<Scalar>(real: Scalar, imaginary: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint {
+        let complex0 = Complex<Scalar>()
+        XCTAssertEqual(complex0.real, 0.0, file: file, line: line)
+        XCTAssertEqual(complex0.imaginary, 0.0, file: file, line: line)
+
+        let complex1 = Complex<Scalar>(real: real, imaginary: imaginary)
+        XCTAssertEqual(complex1.real, real, file: file, line: line)
+        XCTAssertEqual(complex1.imaginary, imaginary, file: file, line: line)
+
+        let complex2 = Complex<Scalar>(complex1)
+        XCTAssertEqual(complex2.real, real, file: file, line: line)
+        XCTAssertEqual(complex2.imaginary, imaginary, file: file, line: line)
+
+        let complex3 = Complex<Int64>(real: real, imaginary: imaginary)
+        XCTAssertEqual(complex3.real, Int64(real), file: file, line: line)
+        XCTAssertEqual(complex3.imaginary, Int64(imaginary), file: file, line: line)
+
+        let complex4 = Complex<Int64>(complex1)
+        XCTAssertEqual(complex4.real, Int64(real), file: file, line: line)
+        XCTAssertEqual(complex4.imaginary, Int64(imaginary), file: file, line: line)
+
+        let complex5 = Complex<Float80>(real: real, imaginary: imaginary)
+        XCTAssertEqual(complex5.real, Float80(real), file: file, line: line)
+        XCTAssertEqual(complex5.imaginary, Float80(imaginary), file: file, line: line)
+
+        let complex6 = Complex<Float80>(complex1)
+        XCTAssertEqual(complex6.real, Float80(real), file: file, line: line)
+        XCTAssertEqual(complex6.imaginary, Float80(imaginary), file: file, line: line)
+
+        let complex7: Complex<Scalar> = []
+        XCTAssertEqual(complex7.real, 0.0, file: file, line: line)
+        XCTAssertEqual(complex7.imaginary, 0.0, file: file, line: line)
+
+        let complex8: Complex<Scalar> = [real]
+        XCTAssertEqual(complex8.real, real, file: file, line: line)
+        XCTAssertEqual(complex8.imaginary, 0.0, file: file, line: line)
+
+        let complex9: Complex<Scalar> = [real, imaginary]
+        XCTAssertEqual(complex9.real, real, file: file, line: line)
+        XCTAssertEqual(complex9.imaginary, imaginary, file: file, line: line)
+    }
+
+    private func testRandomFactoryMethods<Scalar>(lowerBound: Scalar, upperBound: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: FixedWidthInteger {
+        var generator = SystemRandomNumberGenerator()
+        let closedRange: ClosedRange<Scalar> = lowerBound ... upperBound
+        let range: Range<Scalar> = lowerBound ..< upperBound
+
+        let complex1 = Complex<Scalar>.random(in: range)
+        XCTAssertTrue(range.contains(complex1.real), file: file, line: line)
+        XCTAssertTrue(range.contains(complex1.imaginary), file: file, line: line)
+
+        let complex2 = Complex<Scalar>.random(in: range, using: &generator)
+        XCTAssertTrue(range.contains(complex2.real), file: file, line: line)
+        XCTAssertTrue(range.contains(complex2.imaginary), file: file, line: line)
+
+        let complex3 = Complex<Scalar>.random(in: closedRange)
+        XCTAssertTrue(closedRange.contains(complex3.real), file: file, line: line)
+        XCTAssertTrue(closedRange.contains(complex3.imaginary), file: file, line: line)
+
+        let complex4 = Complex<Scalar>.random(in: closedRange, using: &generator)
+        XCTAssertTrue(closedRange.contains(complex4.real), file: file, line: line)
+        XCTAssertTrue(closedRange.contains(complex4.imaginary), file: file, line: line)
+    }
+
+    private func testRandomFactoryMethods<Scalar>(lowerBound: Scalar, upperBound: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint, Scalar.RawSignificand: FixedWidthInteger {
+        var generator = SystemRandomNumberGenerator()
+        let closedRange: ClosedRange<Scalar> = lowerBound ... upperBound
+        let range: Range<Scalar> = lowerBound ..< upperBound
+
+        let complex1 = Complex<Scalar>.random(in: range)
+        XCTAssertTrue(range.contains(complex1.real), file: file, line: line)
+        XCTAssertTrue(range.contains(complex1.imaginary), file: file, line: line)
+
+        let complex2 = Complex<Scalar>.random(in: range, using: &generator)
+        XCTAssertTrue(range.contains(complex2.real), file: file, line: line)
+        XCTAssertTrue(range.contains(complex2.imaginary), file: file, line: line)
+
+        let complex3 = Complex<Scalar>.random(in: closedRange)
+        XCTAssertTrue(closedRange.contains(complex3.real), file: file, line: line)
+        XCTAssertTrue(closedRange.contains(complex3.imaginary), file: file, line: line)
+
+        let complex4 = Complex<Scalar>.random(in: closedRange, using: &generator)
+        XCTAssertTrue(closedRange.contains(complex4.real), file: file, line: line)
+        XCTAssertTrue(closedRange.contains(complex4.imaginary), file: file, line: line)
+    }
+
+    private func testDescriptionMethods<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) throws where Scalar: BinaryInteger {
+        let description = complex.description
+        let debugDescription = complex.debugDescription
+
+        let realRegex = try NSRegularExpression(pattern: "real:[ ]*\(NSRegularExpression.escapedPattern(for: "\(complex.real)"))", options: [])
+        let imaginaryRegex = try NSRegularExpression(pattern: "imaginary:[ ]*\(NSRegularExpression.escapedPattern(for: "\(complex.imaginary)"))", options: [])
+
+        XCTAssertEqual(description, debugDescription, file: file, line: line)
+        XCTAssertTrue(realRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0, file: file, line: line)
+        XCTAssertTrue(imaginaryRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0, file: file, line: line)
+
+        XCTAssertTrue(complex.string(withNotation: .square).contains("\(complex.real)"), file: file, line: line)
+        XCTAssertTrue(complex.string(withNotation: .square).contains("\(complex.imaginary)"), file: file, line: line)
+
+        XCTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.modulus)"), file: file, line: line)
+        XCTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.angle)"), file: file, line: line)
+
+        XCTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.modulus)"), file: file, line: line)
+        XCTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.angle)"), file: file, line: line)
+
+        XCTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.modulus)"), file: file, line: line)
+        XCTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.angle)"), file: file, line: line)
+    }
+
+    private func testDescriptionMethods<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) throws where Scalar: BinaryFloatingPoint {
+        let description = complex.description
+        let debugDescription = complex.debugDescription
+
+        let realRegex = try NSRegularExpression(pattern: "real:[ ]*\(NSRegularExpression.escapedPattern(for: "\(complex.real)"))", options: [])
+        let imaginaryRegex = try NSRegularExpression(pattern: "imaginary:[ ]*\(NSRegularExpression.escapedPattern(for: "\(complex.imaginary)"))", options: [])
+
+        XCTAssertEqual(description, debugDescription, file: file, line: line)
+        XCTAssertTrue(realRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0, file: file, line: line)
+        XCTAssertTrue(imaginaryRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0, file: file, line: line)
+
+        XCTAssertTrue(complex.string(withNotation: .square).contains("\(complex.real)"), file: file, line: line)
+        XCTAssertTrue(complex.string(withNotation: .square).contains("\(complex.imaginary)"), file: file, line: line)
+
+        XCTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.modulus)"), file: file, line: line)
+        XCTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.angle)"), file: file, line: line)
+
+        XCTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.modulus)"), file: file, line: line)
+        XCTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.angle)"), file: file, line: line)
+
+        XCTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.modulus)"), file: file, line: line)
+        XCTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.angle)"), file: file, line: line)
+    }
+
+    private func testHashing<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: Hashable {
         var hasher = Hasher()
-        hasher.combine(half)
-        _ = hasher.finalize()
+        hasher.combine(complex)
+        let value1 = hasher.finalize()
 
-        let float = Complex<Float>(real: 1.0, imaginary: 2.0)
         hasher = Hasher()
-        hasher.combine(float)
-        _ = hasher.finalize()
+        hasher.combine(complex.real)
+        hasher.combine(complex.imaginary)
+        let value2 = hasher.finalize()
 
-        let double = Complex<Double>(real: 1.0, imaginary: 2.0)
-        hasher = Hasher()
-        hasher.combine(double)
-        _ = hasher.finalize()
-
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        let float80 = Complex<Float80>(real: 1.0, imaginary: 2.0)
-        hasher = Hasher()
-        hasher.combine(float80)
-        _ = hasher.finalize()
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+        XCTAssertEqual(value1, value2, file: file, line: line)
     }
 
-    func testMultiplicationAndDivision() {
-        do {
-            let lhs = Complex<Half>(real: 3.0, imaginary: 2.0)
-            let rhs = Complex<Half>(real: 1.0, imaginary: 7.0)
-            var value = lhs
-            value *= rhs
+    private func testRounding<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: FloatingPoint {
+        XCTAssertEqual(complex.rounded(), Complex(real: complex.real.rounded(), imaginary: complex.imaginary.rounded()), file: file, line: line)
 
-            XCTAssertEqual(lhs * rhs, Complex(real: -11.0, imaginary: 23.0))
-            XCTAssertEqual(value, Complex(real: -11.0, imaginary: 23.0))
-            XCTAssertEqual(value, lhs * rhs)
+        var rounded = complex
+        rounded.round()
+        XCTAssertEqual(rounded, complex.rounded(), file: file, line: line)
 
-            value = lhs
-            value /= rhs
+        for rule in [FloatingPointRoundingRule.toNearestOrAwayFromZero, .toNearestOrEven, .up, .down, .towardZero, .awayFromZero] {
+            XCTAssertEqual(complex.rounded(rule), Complex(real: complex.real.rounded(rule), imaginary: complex.imaginary.rounded(rule)), file: file, line: line)
 
-            XCTAssertEqual(lhs / rhs, Complex(real: 0.34, imaginary: -0.38))
-            XCTAssertEqual(value, Complex(real: 0.34, imaginary: -0.38))
-            XCTAssertEqual(value, lhs / rhs)
+            var rounded = complex
+            rounded.round(rule)
+            XCTAssertEqual(rounded, complex.rounded(rule), file: file, line: line)
         }
-        do {
-            let lhs = Complex<Float>(real: 3.0, imaginary: 2.0)
-            let rhs = Complex<Float>(real: 1.0, imaginary: 7.0)
-            var value = lhs
-            value *= rhs
-
-            XCTAssertEqual(lhs * rhs, Complex(real: -11.0, imaginary: 23.0))
-            XCTAssertEqual(value, Complex(real: -11.0, imaginary: 23.0))
-            XCTAssertEqual(value, lhs * rhs)
-
-            value = lhs
-            value /= rhs
-
-            XCTAssertEqual(lhs / rhs, Complex(real: 0.34, imaginary: -0.38))
-            XCTAssertEqual(value, Complex(real: 0.34, imaginary: -0.38))
-            XCTAssertEqual(value, lhs / rhs)
-        }
-        do {
-            let lhs = Complex<Double>(real: 3.0, imaginary: 2.0)
-            let rhs = Complex<Double>(real: 1.0, imaginary: 7.0)
-            var value = lhs
-            value *= rhs
-
-            XCTAssertEqual(lhs * rhs, Complex(real: -11.0, imaginary: 23.0))
-            XCTAssertEqual(value, Complex(real: -11.0, imaginary: 23.0))
-            XCTAssertEqual(value, lhs * rhs)
-
-            value = lhs
-            value /= rhs
-
-            XCTAssertEqual(lhs / rhs, Complex(real: 0.34, imaginary: -0.38))
-            XCTAssertEqual(value, Complex(real: 0.34, imaginary: -0.38))
-            XCTAssertEqual(value, lhs / rhs)
-        }
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        do {
-            let lhs = Complex<Float80>(real: 3.0, imaginary: 2.0)
-            let rhs = Complex<Float80>(real: 1.0, imaginary: 7.0)
-            var value = lhs
-            value *= rhs
-
-            XCTAssertEqual(lhs * rhs, Complex(real: -11.0, imaginary: 23.0))
-            XCTAssertEqual(value, Complex(real: -11.0, imaginary: 23.0))
-            XCTAssertEqual(value, lhs * rhs)
-
-            value = lhs
-            value /= rhs
-
-            XCTAssertTrue(((lhs / rhs) - Complex(real: 0.34, imaginary: -0.38)).modulus < 0.0001)
-            XCTAssertTrue((value - Complex(real: 0.34, imaginary: -0.38)).modulus < 0.0001)
-            XCTAssertEqual(value, lhs / rhs)
-        }
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     }
 
-    func testComplexArithmeticWithRealNumbers() {
-        do {
-            let complex = Complex<Half>(real: 3.0, imaginary: 2.0)
-            let real: Half = 5.0
-            var value = complex
-            value += real
+    private func testConjugateMethods<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
+        var conjugate = complex.conjugate()
+        XCTAssertEqual(complex.real, conjugate.real, file: file, line: line)
+        XCTAssertEqual(complex.imaginary, -conjugate.imaginary, file: file, line: line)
 
-            XCTAssertEqual(complex + real, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(real + complex, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(value, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(value, complex + real)
-            XCTAssertEqual(value, real + complex)
+        conjugate = ~complex
+        XCTAssertEqual(complex.real, conjugate.real, file: file, line: line)
+        XCTAssertEqual(complex.imaginary, -conjugate.imaginary, file: file, line: line)
 
-            value = complex
-            value -= real
-
-            XCTAssertEqual(complex - real, Complex(real: -2.0, imaginary: 2.0))
-            XCTAssertEqual(real - complex, Complex(real: 2.0, imaginary: -2.0))
-            XCTAssertEqual(value, Complex(real: -2.0, imaginary: 2.0))
-            XCTAssertEqual(value, complex - real)
-            XCTAssertEqual(-value, real - complex)
-
-            value = complex
-            value *= real
-
-            XCTAssertEqual(complex * real, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(real * complex, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(value, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(value, complex * real)
-            XCTAssertEqual(value, real * complex)
-
-            value = complex
-            value /= real
-
-            XCTAssertEqual(complex / real, Complex(real: 0.6, imaginary: 0.4))
-            XCTAssertEqual(real / complex, Complex(real: 1.1542969, imaginary: -0.76904297))
-            XCTAssertEqual(value, Complex(real: 0.6, imaginary: 0.4))
-            XCTAssertEqual(value, complex / real)
-        }
-        do {
-            let complex = Complex<Float>(real: 3.0, imaginary: 2.0)
-            let real: Float = 5.0
-            var value = complex
-            value += real
-
-            XCTAssertEqual(complex + real, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(real + complex, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(value, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(value, complex + real)
-            XCTAssertEqual(value, real + complex)
-
-            value = complex
-            value -= real
-
-            XCTAssertEqual(complex - real, Complex(real: -2.0, imaginary: 2.0))
-            XCTAssertEqual(real - complex, Complex(real: 2.0, imaginary: -2.0))
-            XCTAssertEqual(value, Complex(real: -2.0, imaginary: 2.0))
-            XCTAssertEqual(value, complex - real)
-            XCTAssertEqual(-value, real - complex)
-
-            value = complex
-            value *= real
-
-            XCTAssertEqual(complex * real, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(real * complex, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(value, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(value, complex * real)
-            XCTAssertEqual(value, real * complex)
-
-            value = complex
-            value /= real
-
-            XCTAssertEqual(complex / real, Complex(real: 0.6, imaginary: 0.4))
-            XCTAssertTrue(((real / complex) - Complex(real: 1.1542969, imaginary: -0.76904297)).modulus < 0.001)
-            XCTAssertEqual(value, Complex(real: 0.6, imaginary: 0.4))
-            XCTAssertEqual(value, complex / real)
-        }
-        do {
-            let complex = Complex<Double>(real: 3.0, imaginary: 2.0)
-            let real: Double = 5.0
-            var value = complex
-            value += real
-
-            XCTAssertEqual(complex + real, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(real + complex, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(value, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(value, complex + real)
-            XCTAssertEqual(value, real + complex)
-
-            value = complex
-            value -= real
-
-            XCTAssertEqual(complex - real, Complex(real: -2.0, imaginary: 2.0))
-            XCTAssertEqual(real - complex, Complex(real: 2.0, imaginary: -2.0))
-            XCTAssertEqual(value, Complex(real: -2.0, imaginary: 2.0))
-            XCTAssertEqual(value, complex - real)
-            XCTAssertEqual(-value, real - complex)
-
-            value = complex
-            value *= real
-
-            XCTAssertEqual(complex * real, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(real * complex, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(value, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(value, complex * real)
-            XCTAssertEqual(value, real * complex)
-
-            value = complex
-            value /= real
-
-            XCTAssertEqual(complex / real, Complex(real: 0.6, imaginary: 0.4))
-            XCTAssertTrue(((real / complex) - Complex(real: 1.1542969, imaginary: -0.76904297)).modulus < 0.001)
-            XCTAssertEqual(value, Complex(real: 0.6, imaginary: 0.4))
-            XCTAssertEqual(value, complex / real)
-        }
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        do {
-            let complex = Complex<Float80>(real: 3.0, imaginary: 2.0)
-            let real: Float80 = 5.0
-            var value = complex
-            value += real
-
-            XCTAssertEqual(complex + real, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(real + complex, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(value, Complex(real: 8.0, imaginary: 2.0))
-            XCTAssertEqual(value, complex + real)
-            XCTAssertEqual(value, real + complex)
-
-            value = complex
-            value -= real
-
-            XCTAssertEqual(complex - real, Complex(real: -2.0, imaginary: 2.0))
-            XCTAssertEqual(real - complex, Complex(real: 2.0, imaginary: -2.0))
-            XCTAssertEqual(value, Complex(real: -2.0, imaginary: 2.0))
-            XCTAssertEqual(value, complex - real)
-            XCTAssertEqual(-value, real - complex)
-
-            value = complex
-            value *= real
-
-            XCTAssertEqual(complex * real, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(real * complex, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(value, Complex(real: 15.0, imaginary: 10.0))
-            XCTAssertEqual(value, complex * real)
-            XCTAssertEqual(value, real * complex)
-
-            value = complex
-            value /= real
-
-            XCTAssertTrue(((complex / real) - Complex(real: 0.6, imaginary: 0.4)).modulus < 0.001)
-            XCTAssertTrue(((real / complex) - Complex(real: 1.1542969, imaginary: -0.76904297)).modulus < 0.001)
-            XCTAssertTrue((value - Complex(real: 0.6, imaginary: 0.4)).modulus < 0.001)
-            XCTAssertEqual(value, complex / real)
-        }
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+        conjugate = complex
+        conjugate.formConjugate()
+        XCTAssertEqual(complex.real, conjugate.real, file: file, line: line)
+        XCTAssertEqual(complex.imaginary, -conjugate.imaginary, file: file, line: line)
     }
 
-    func testNegation() {
-        do {
-            var complex = Complex<Half>(real: -7.0, imaginary: 4.0)
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
+    private func testNegationMethods<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
+        var negative = -complex
+        XCTAssertEqual(complex.real, -negative.real, file: file, line: line)
+        XCTAssertEqual(complex.imaginary, -negative.imaginary, file: file, line: line)
 
-            complex.negate()
-            XCTAssertEqual(complex.real, 7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-
-            complex = -complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = +complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-        }
-        do {
-            var complex = Complex<Float>(real: -7.0, imaginary: 4.0)
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex.negate()
-            XCTAssertEqual(complex.real, 7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-
-            complex = -complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = +complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-        }
-        do {
-            var complex = Complex<Double>(real: -7.0, imaginary: 4.0)
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex.negate()
-            XCTAssertEqual(complex.real, 7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-
-            complex = -complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = +complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-        }
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        do {
-            var complex = Complex<Float80>(real: -7.0, imaginary: 4.0)
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex.negate()
-            XCTAssertEqual(complex.real, 7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-
-            complex = -complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = +complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-        }
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+        negative = complex
+        negative.negate()
+        XCTAssertEqual(complex.real, -negative.real, file: file, line: line)
+        XCTAssertEqual(complex.imaginary, -negative.imaginary, file: file, line: line)
     }
 
-    func testConjugates() {
-        do {
-            var complex = Complex<Half>(real: -7.0, imaginary: 4.0)
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
+    private func testMultiplyByOne<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        let one = Complex<Scalar>.one
+        let result = complex * one
 
-            complex.formConjugate()
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-
-            complex = complex.conjugate()
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = ~complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-        }
-        do {
-            var complex = Complex<Float>(real: -7.0, imaginary: 4.0)
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex.formConjugate()
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-
-            complex = complex.conjugate()
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = ~complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-        }
-        do {
-            var complex = Complex<Double>(real: -7.0, imaginary: 4.0)
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex.formConjugate()
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-
-            complex = complex.conjugate()
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = ~complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-        }
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        do {
-            var complex = Complex<Float80>(real: -7.0, imaginary: 4.0)
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex.formConjugate()
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-
-            complex = complex.conjugate()
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, 4.0)
-
-            complex = ~complex
-            XCTAssertEqual(complex.real, -7.0)
-            XCTAssertEqual(complex.imaginary, -4.0)
-        }
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+        XCTAssertEqual(result, complex, file: file, line: line)
     }
 
-    func testRounding() {
-        do {
-            let complex = Complex<Half>(real: 1.5, imaginary: -4.5)
-            XCTAssertEqual(complex.rounded(), Complex(real: 2.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.toNearestOrAwayFromZero), Complex(real: 2.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.toNearestOrEven), Complex(real: 2.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.up), Complex(real: 2.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.down), Complex(real: 1.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.towardZero), Complex(real: 1.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.awayFromZero), Complex(real: 2.0, imaginary: -5.0))
+    private func testMultiplyByI<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
+        let i = Complex<Scalar>.i
+        let result = complex * i
 
-            var value = complex
-            value.round()
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.toNearestOrAwayFromZero)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.toNearestOrEven)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.up)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.down)
-            XCTAssertEqual(value, Complex(real: 1.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.towardZero)
-            XCTAssertEqual(value, Complex(real: 1.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.awayFromZero)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-        }
-        do {
-            let complex = Complex<Float>(real: 1.5, imaginary: -4.5)
-            XCTAssertEqual(complex.rounded(), Complex(real: 2.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.toNearestOrAwayFromZero), Complex(real: 2.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.toNearestOrEven), Complex(real: 2.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.up), Complex(real: 2.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.down), Complex(real: 1.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.towardZero), Complex(real: 1.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.awayFromZero), Complex(real: 2.0, imaginary: -5.0))
-
-            var value = complex
-            value.round()
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.toNearestOrAwayFromZero)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.toNearestOrEven)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.up)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.down)
-            XCTAssertEqual(value, Complex(real: 1.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.towardZero)
-            XCTAssertEqual(value, Complex(real: 1.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.awayFromZero)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-        }
-        do {
-            let complex = Complex<Double>(real: 1.5, imaginary: -4.5)
-            XCTAssertEqual(complex.rounded(), Complex(real: 2.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.toNearestOrAwayFromZero), Complex(real: 2.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.toNearestOrEven), Complex(real: 2.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.up), Complex(real: 2.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.down), Complex(real: 1.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.towardZero), Complex(real: 1.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.awayFromZero), Complex(real: 2.0, imaginary: -5.0))
-
-            var value = complex
-            value.round()
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.toNearestOrAwayFromZero)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.toNearestOrEven)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.up)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.down)
-            XCTAssertEqual(value, Complex(real: 1.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.towardZero)
-            XCTAssertEqual(value, Complex(real: 1.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.awayFromZero)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-        }
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        do {
-            let complex = Complex<Float80>(real: 1.5, imaginary: -4.5)
-            XCTAssertEqual(complex.rounded(), Complex(real: 2.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.toNearestOrAwayFromZero), Complex(real: 2.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.toNearestOrEven), Complex(real: 2.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.up), Complex(real: 2.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.down), Complex(real: 1.0, imaginary: -5.0))
-            XCTAssertEqual(complex.rounded(.towardZero), Complex(real: 1.0, imaginary: -4.0))
-            XCTAssertEqual(complex.rounded(.awayFromZero), Complex(real: 2.0, imaginary: -5.0))
-
-            var value = complex
-            value.round()
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.toNearestOrAwayFromZero)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.toNearestOrEven)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.up)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.down)
-            XCTAssertEqual(value, Complex(real: 1.0, imaginary: -5.0))
-
-            value = complex
-            value.round(.towardZero)
-            XCTAssertEqual(value, Complex(real: 1.0, imaginary: -4.0))
-
-            value = complex
-            value.round(.awayFromZero)
-            XCTAssertEqual(value, Complex(real: 2.0, imaginary: -5.0))
-        }
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+        XCTAssertEqual(result.real, -complex.imaginary, file: file, line: line)
+        XCTAssertEqual(result.imaginary, complex.real, file: file, line: line)
     }
 
-    func testPolarComponents() {
-        do {
-            let complex = Complex<Half>(real: 3.0, imaginary: 4.0)
-            XCTAssertEqual(complex.modulus, 5.0)
-            XCTAssertEqual(complex.angle, 0.9272461)
-        }
-        do {
-            let complex = Complex<Float>(real: 3.0, imaginary: 4.0)
-            XCTAssertEqual(complex.modulus, 5.0)
-            XCTAssertEqual(complex.angle, 0.9272952)
-        }
-        do {
-            let complex = Complex<Double>(real: 3.0, imaginary: 4.0)
-            XCTAssertEqual(complex.modulus, 5.0)
-            XCTAssertEqual(complex.angle, 0.9272952180016122)
-        }
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-        do {
-            let complex = Complex<Float80>(real: 3.0, imaginary: 4.0)
-            XCTAssertEqual(complex.modulus, 5.0)
-            XCTAssertEqual(complex.angle, 0.9272952180016122324)
-        }
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+    private func testPlusPrefixOperator<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(complex, +complex, file: file, line: line)
+    }
+
+    private func testPolarComponents<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint {
+        XCTAssertEqual(complex.modulus, sqrt(complex.real * complex.real + complex.imaginary * complex.imaginary), file: file, line: line)
+        XCTAssertEqual(complex.angle, Scalar(atan2(Float80(complex.imaginary), Float80(complex.real))), file: file, line: line)
     }
 }

--- a/Tests/ComplexTests/FunctionsTests.swift
+++ b/Tests/ComplexTests/FunctionsTests.swift
@@ -23,10 +23,8 @@ class FunctionsTests: XCTestCase {
         XCTAssertEqual(csqrt(Double(-4.0)), Complex(real: 0.0, imaginary: 2.0))
         XCTAssertEqual(csqrt(Double(9.0)), Complex(real: 3.0, imaginary: 0.0))
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
         XCTAssertEqual(csqrt(Float80(-4.0)), Complex(real: 0.0, imaginary: 2.0))
         XCTAssertEqual(csqrt(Float80(9.0)), Complex(real: 3.0, imaginary: 0.0))
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     }
 
     func test_sqrt() {
@@ -51,41 +49,33 @@ class FunctionsTests: XCTestCase {
         XCTAssertEqual(sqrt(Complex<Double>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
         XCTAssertEqual(sqrt(Complex<Double>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
         XCTAssertEqual(sqrt(Complex<Float80>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
         XCTAssertEqual(sqrt(Complex<Float80>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
         XCTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: -4.0)) - Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot())).modulus < 0.0001)
         XCTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: 4.0)) - Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot())).modulus < 0.0001)
         XCTAssertEqual(sqrt(Complex<Float80>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
         XCTAssertEqual(sqrt(Complex<Float80>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     }
 
     func test_abs() {
         XCTAssertEqual(abs(Complex<Half>(real: -4.5, imaginary: 3.7)), Complex<Half>(real: 4.5, imaginary: 3.7))
         XCTAssertEqual(abs(Complex<Float>(real: -4.5, imaginary: 3.7)), Complex<Float>(real: 4.5, imaginary: 3.7))
         XCTAssertEqual(abs(Complex<Double>(real: -4.5, imaginary: 3.7)), Complex<Double>(real: 4.5, imaginary: 3.7))
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
         XCTAssertEqual(abs(Complex<Float80>(real: -4.5, imaginary: 3.7)), Complex<Float80>(real: 4.5, imaginary: 3.7))
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     }
 
     func test_min() {
         XCTAssertEqual(min(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: -4.5, imaginary: 1.2))
         XCTAssertEqual(min(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: -4.5, imaginary: 1.2))
         XCTAssertEqual(min(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: -4.5, imaginary: 1.2))
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
         XCTAssertEqual(min(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: -4.5, imaginary: 1.2))
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     }
 
     func test_max() {
         XCTAssertEqual(max(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: 7.0, imaginary: 3.7))
         XCTAssertEqual(max(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: 7.0, imaginary: 3.7))
         XCTAssertEqual(max(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: 7.0, imaginary: 3.7))
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
         XCTAssertEqual(max(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: 7.0, imaginary: 3.7))
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     }
 
     func test_clamp() {
@@ -97,9 +87,7 @@ class FunctionsTests: XCTestCase {
 
         XCTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Double>(real: -4.0, imaginary: 3.7))
         XCTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 0.0, imaginary: 0.0), Complex<Double>(real: 2.0, imaginary: 4.0)), Complex<Double>(real: 0.0, imaginary: 3.7))
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
         XCTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Float80>(real: -4.0, imaginary: 3.7))
         XCTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 0.0, imaginary: 0.0), Complex<Float80>(real: 2.0, imaginary: 4.0)), Complex<Float80>(real: 0.0, imaginary: 3.7))
-#endif // #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
     }
 }


### PR DESCRIPTION
Complex, as now shown by the unit tests, work with any type conforming to `Numeric` including but not limited to `Int8`, `Int16`, `Int32`, `Int64`, `Int`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `UInt`