### PR TITLE
Reduced compile time by breaking up complex statements into smaller components

### DIFF
--- a/Sources/Complex/Functions.swift
+++ b/Sources/Complex/Functions.swift
@@ -158,17 +158,32 @@ public func sin(_ value: Complex<Float80>) -> Complex<Float80> {
 
 @_transparent
 public func asin(_ value: Complex<Float>) -> Complex<Float> {
-    return -.i * log(.i * value + sqrt(1.0 - value * value))
+    //swiftlint:disable identifier_name
+    let iz = .i * value
+    let root = sqrt(1.0 - (value * value))
+
+    return -.i * log(iz + root)
+    //swiftlint:enable identifier_name
 }
 
 @_transparent
 public func asin(_ value: Complex<Double>) -> Complex<Double> {
-    return -.i * log(.i * value + sqrt(1.0 - value * value))
+    //swiftlint:disable identifier_name
+    let iz = .i * value
+    let root = sqrt(1.0 - (value * value))
+
+    return -.i * log(iz + root)
+    //swiftlint:enable identifier_name
 }
 
 @_transparent
 public func asin(_ value: Complex<Float80>) -> Complex<Float80> {
-    return -.i * log(.i * value + sqrt(1.0 - value * value))
+    //swiftlint:disable identifier_name
+    let iz = .i * value
+    let root = sqrt(1.0 - (value * value))
+
+    return -.i * log(iz + root)
+    //swiftlint:enable identifier_name
 }
 
 //
@@ -212,17 +227,20 @@ public func cos(_ value: Complex<Float80>) -> Complex<Float80> {
 
 @_transparent
 public func acos(_ value: Complex<Float>) -> Complex<Float> {
-    return -.i * log(value + sqrt(value * value - 1.0))
+    let root = sqrt((value * value) - 1.0)
+    return -.i * log(value + root)
 }
 
 @_transparent
 public func acos(_ value: Complex<Double>) -> Complex<Double> {
-    return -.i * log(value + sqrt(value * value - 1.0))
+    let root = sqrt((value * value) - 1.0)
+    return -.i * log(value + root)
 }
 
 @_transparent
 public func acos(_ value: Complex<Float80>) -> Complex<Float80> {
-    return -.i * log(value + sqrt(value * value - 1.0))
+    let root = sqrt((value * value) - 1.0)
+    return -.i * log(value + root)
 }
 
 //
@@ -265,17 +283,20 @@ public func tan(_ value: Complex<Float80>) -> Complex<Float80> {
 
 @_transparent
 public func atan(_ value: Complex<Float>) -> Complex<Float> {
-    return .i * 0.5 * log((.i + value) / (.i - value))
+    let quotient = (.i + value) / (.i - value)
+    return .i * 0.5 * log(quotient)
 }
 
 @_transparent
 public func atan(_ value: Complex<Double>) -> Complex<Double> {
-    return .i * 0.5 * log((.i + value) / (.i - value))
+    let quotient = (.i + value) / (.i - value)
+    return .i * 0.5 * log(quotient)
 }
 
 @_transparent
 public func atan(_ value: Complex<Float80>) -> Complex<Float80> {
-    return .i * 0.5 * log((.i + value) / (.i - value))
+    let quotient = (.i + value) / (.i - value)
+    return .i * 0.5 * log(quotient)
 }
 
 //

--- a/Sources/Complex/Functions.swift.gyb
+++ b/Sources/Complex/Functions.swift.gyb
@@ -117,7 +117,12 @@ public func sin(_ value: Complex<${type}>) -> Complex<${type}> {
 % for type in ["Float", "Double", "Float80"]:
 @_transparent
 public func asin(_ value: Complex<${type}>) -> Complex<${type}> {
-    return -.i * log(.i * value + sqrt(1.0 - value * value))
+    //swiftlint:disable identifier_name
+    let iz = .i * value
+    let root = sqrt(1.0 - (value * value))
+
+    return -.i * log(iz + root)
+    //swiftlint:enable identifier_name
 }
 
 % end
@@ -147,7 +152,8 @@ public func cos(_ value: Complex<${type}>) -> Complex<${type}> {
 % for type in ["Float", "Double", "Float80"]:
 @_transparent
 public func acos(_ value: Complex<${type}>) -> Complex<${type}> {
-    return -.i * log(value + sqrt(value * value - 1.0))
+    let root = sqrt((value * value) - 1.0)
+    return -.i * log(value + root)
 }
 
 % end
@@ -176,7 +182,8 @@ public func tan(_ value: Complex<${type}>) -> Complex<${type}> {
 % for type in ["Float", "Double", "Float80"]:
 @_transparent
 public func atan(_ value: Complex<${type}>) -> Complex<${type}> {
-    return .i * 0.5 * log((.i + value) / (.i - value))
+    let quotient = (.i + value) / (.i - value)
+    return .i * 0.5 * log(quotient)
 }
 
 % end

--- a/Tests/ComplexTests/FunctionsTests.swift
+++ b/Tests/ComplexTests/FunctionsTests.swift
@@ -156,13 +156,31 @@ class FunctionsTests: XCTestCase {
 
     func test_asin() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(asin(complex), -.i * log(.i * complex + sqrt(1.0 - complex * complex)), accuracy: 0.0001)
+            //swiftlint:disable identifier_name
+            let iz = .i * complex
+            let root = sqrt(1.0 - (complex * complex))
+            let result = -.i * log(iz + root)
+            //swiftlint:enable identifier_name
+
+            XCTAssertEqual(asin(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(asin(complex), -.i * log(.i * complex + sqrt(1.0 - complex * complex)), accuracy: 0.0001)
+            //swiftlint:disable identifier_name
+            let iz = .i * complex
+            let root = sqrt(1.0 - (complex * complex))
+            let result = -.i * log(iz + root)
+            //swiftlint:enable identifier_name
+
+            XCTAssertEqual(asin(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(asin(complex), -.i * log(.i * complex + sqrt(1.0 - complex * complex)), accuracy: 0.0001)
+            //swiftlint:disable identifier_name
+            let iz = .i * complex
+            let root = sqrt(1.0 - (complex * complex))
+            let result = -.i * log(iz + root)
+            //swiftlint:enable identifier_name
+
+            XCTAssertEqual(asin(complex), result, accuracy: 0.0001)
         }
     }
 
@@ -192,13 +210,22 @@ class FunctionsTests: XCTestCase {
 
     func test_acos() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(acos(complex), -.i * log(complex + sqrt(complex * complex - 1.0)), accuracy: 0.0001)
+            let root = sqrt((complex * complex) - 1.0)
+            let result = -.i * log(complex + root)
+
+            XCTAssertEqual(acos(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(acos(complex), -.i * log(complex + sqrt(complex * complex - 1.0)), accuracy: 0.0001)
+            let root = sqrt((complex * complex) - 1.0)
+            let result = -.i * log(complex + root)
+
+            XCTAssertEqual(acos(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(acos(complex), -.i * log(complex + sqrt(complex * complex - 1.0)), accuracy: 0.0001)
+            let root = sqrt((complex * complex) - 1.0)
+            let result = -.i * log(complex + root)
+
+            XCTAssertEqual(acos(complex), result, accuracy: 0.0001)
         }
     }
 
@@ -228,13 +255,22 @@ class FunctionsTests: XCTestCase {
 
     func test_atan() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(atan(complex), .i * 0.5 * log((.i + complex) / (.i - complex)), accuracy: 0.0001)
+            let quotient = (.i + complex) / (.i - complex)
+            let result = .i * 0.5 * log(quotient)
+
+            XCTAssertEqual(atan(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(atan(complex), .i * 0.5 * log((.i + complex) / (.i - complex)), accuracy: 0.0001)
+            let quotient = (.i + complex) / (.i - complex)
+            let result = .i * 0.5 * log(quotient)
+
+            XCTAssertEqual(atan(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(atan(complex), .i * 0.5 * log((.i + complex) / (.i - complex)), accuracy: 0.0001)
+            let quotient = (.i + complex) / (.i - complex)
+            let result = .i * 0.5 * log(quotient)
+
+            XCTAssertEqual(atan(complex), result, accuracy: 0.0001)
         }
     }
 

--- a/Tests/ComplexTests/FunctionsTests.swift.gyb
+++ b/Tests/ComplexTests/FunctionsTests.swift.gyb
@@ -135,7 +135,13 @@ class FunctionsTests: XCTestCase {
     func test_asin() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(asin(complex), -.i * log(.i * complex + sqrt(1.0 - complex * complex)), accuracy: 0.0001)
+            //swiftlint:disable identifier_name
+            let iz = .i * complex
+            let root = sqrt(1.0 - (complex * complex))
+            let result = -.i * log(iz + root)
+            //swiftlint:enable identifier_name
+
+            XCTAssertEqual(asin(complex), result, accuracy: 0.0001)
         }
         % end
     }
@@ -159,7 +165,10 @@ class FunctionsTests: XCTestCase {
     func test_acos() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(acos(complex), -.i * log(complex + sqrt(complex * complex - 1.0)), accuracy: 0.0001)
+            let root = sqrt((complex * complex) - 1.0)
+            let result = -.i * log(complex + root)
+
+            XCTAssertEqual(acos(complex), result, accuracy: 0.0001)
         }
         % end
     }
@@ -183,7 +192,10 @@ class FunctionsTests: XCTestCase {
     func test_atan() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(atan(complex), .i * 0.5 * log((.i + complex) / (.i - complex)), accuracy: 0.0001)
+            let quotient = (.i + complex) / (.i - complex)
+            let result = .i * 0.5 * log(quotient)
+
+            XCTAssertEqual(atan(complex), result, accuracy: 0.0001)
         }
         % end
     }


### PR DESCRIPTION
`Functions.swift` and `FunctionsTests.swift` each used to take around 30 seconds to compile. This has been reduced to approximately 1-2 seconds for each file