### PR TITLE
Created in-house assert testing functions for better propagating source method/type of assertion failures

### DIFF
--- a/Complex.xcodeproj/project.pbxproj
+++ b/Complex.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		DD6F08CD240077C300749359 /* TestingBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6F08CC240077C300749359 /* TestingBase.swift */; };
+		DD6F08CE240077C300749359 /* TestingBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6F08CC240077C300749359 /* TestingBase.swift */; };
+		DD6F08CF240077C300749359 /* TestingBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6F08CC240077C300749359 /* TestingBase.swift */; };
 		DDB8120723F59B760079FEB5 /* Complex.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8120623F59B760079FEB5 /* Complex.swift */; };
 		DDB8120823F59B760079FEB5 /* Complex.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8120623F59B760079FEB5 /* Complex.swift */; };
 		DDB8120923F59B760079FEB5 /* Complex.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB8120623F59B760079FEB5 /* Complex.swift */; };
@@ -146,6 +149,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		DD6F08CC240077C300749359 /* TestingBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingBase.swift; sourceTree = "<group>"; };
 		DDB8120623F59B760079FEB5 /* Complex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Complex.swift; sourceTree = "<group>"; };
 		DDB8120B23F5A8E80079FEB5 /* Functions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
 		DDB8121023F5AEB10079FEB5 /* ComplexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplexTests.swift; sourceTree = "<group>"; };
@@ -302,6 +306,7 @@
 		DDFEEC4023EF13910096015C /* ComplexTests */ = {
 			isa = PBXGroup;
 			children = (
+				DD6F08CC240077C300749359 /* TestingBase.swift */,
 				DDB8121023F5AEB10079FEB5 /* ComplexTests.swift */,
 				DDB8126623F7B7F40079FEB5 /* ComplexArithmeticTests.swift */,
 				DDB8122023F656AC0079FEB5 /* FunctionsTests.swift */,
@@ -699,6 +704,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDB8126723F7B7F40079FEB5 /* ComplexArithmeticTests.swift in Sources */,
+				DD6F08CD240077C300749359 /* TestingBase.swift in Sources */,
 				DDB8121123F5AEB10079FEB5 /* ComplexTests.swift in Sources */,
 				DDB8122123F656AC0079FEB5 /* FunctionsTests.swift in Sources */,
 			);
@@ -720,6 +726,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDB8126823F7B7F40079FEB5 /* ComplexArithmeticTests.swift in Sources */,
+				DD6F08CE240077C300749359 /* TestingBase.swift in Sources */,
 				DDB8121223F5AEB10079FEB5 /* ComplexTests.swift in Sources */,
 				DDB8122223F656AC0079FEB5 /* FunctionsTests.swift in Sources */,
 			);
@@ -741,6 +748,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDB8126923F7B7F40079FEB5 /* ComplexArithmeticTests.swift in Sources */,
+				DD6F08CF240077C300749359 /* TestingBase.swift in Sources */,
 				DDB8121323F5AEB10079FEB5 /* ComplexTests.swift in Sources */,
 				DDB8122323F656AC0079FEB5 /* FunctionsTests.swift in Sources */,
 			);

--- a/Complex.xcodeproj/project.pbxproj
+++ b/Complex.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 
 /* Begin PBXFileReference section */
 		DD6F08CC240077C300749359 /* TestingBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingBase.swift; sourceTree = "<group>"; };
+		DD6F08D02400808300749359 /* codecov.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = codecov.yml; sourceTree = "<group>"; };
 		DDB8120623F59B760079FEB5 /* Complex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Complex.swift; sourceTree = "<group>"; };
 		DDB8120B23F5A8E80079FEB5 /* Functions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
 		DDB8121023F5AEB10079FEB5 /* ComplexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplexTests.swift; sourceTree = "<group>"; };
@@ -330,6 +331,7 @@
 				DDFEECAB23F1BA550096015C /* Complex.podspec */,
 				DDB8121423F634770079FEB5 /* Cartfile.private */,
 				DDFEECAC23F1BA550096015C /* Package.swift */,
+				DD6F08D02400808300749359 /* codecov.yml */,
 				DDFEECAE23F1BA5E0096015C /* .swiftlint.yml */,
 				DDFEECAD23F1BA5E0096015C /* .travis.yml */,
 				DDFEECAF23F1BA680096015C /* README.md */,

--- a/Tests/ComplexTests/ComplexArithmeticTests.swift
+++ b/Tests/ComplexTests/ComplexArithmeticTests.swift
@@ -320,91 +320,91 @@ class ComplexArithmeticTests: XCTestCase {
     // MARK: Private Methods
 
     private func testAdditionWithZero<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(complex, complex + .zero, file: file, line: line)
-        XCTAssertEqual(complex, complex .+ .zero, file: file, line: line)
-        XCTAssertEqual(complex, complex + Scalar.zero, file: file, line: line)
-        XCTAssertEqual(complex, Scalar.zero + complex, file: file, line: line)
+        CTAssertEqual(complex, complex + .zero, file: file, line: line)
+        CTAssertEqual(complex, complex .+ .zero, file: file, line: line)
+        CTAssertEqual(complex, complex + Scalar.zero, file: file, line: line)
+        CTAssertEqual(complex, Scalar.zero + complex, file: file, line: line)
 
         var result = complex
         result += .zero
-        XCTAssertEqual(result, complex, file: file, line: line)
+        CTAssertEqual(result, complex, file: file, line: line)
 
         result = complex
         result .+= .zero
-        XCTAssertEqual(result, complex, file: file, line: line)
+        CTAssertEqual(result, complex, file: file, line: line)
 
         result = complex
         result += Scalar.zero
-        XCTAssertEqual(result, complex, file: file, line: line)
+        CTAssertEqual(result, complex, file: file, line: line)
     }
 
     private func testSubtractionWithZero<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(complex, complex - .zero, file: file, line: line)
-        XCTAssertEqual(complex, complex .- .zero, file: file, line: line)
-        XCTAssertEqual(complex, complex - Scalar.zero, file: file, line: line)
+        CTAssertEqual(complex, complex - .zero, file: file, line: line)
+        CTAssertEqual(complex, complex .- .zero, file: file, line: line)
+        CTAssertEqual(complex, complex - Scalar.zero, file: file, line: line)
 
         var result = complex
         result -= .zero
-        XCTAssertEqual(result, complex, file: file, line: line)
+        CTAssertEqual(result, complex, file: file, line: line)
 
         result = complex
         result .-= .zero
-        XCTAssertEqual(result, complex, file: file, line: line)
+        CTAssertEqual(result, complex, file: file, line: line)
 
         result = complex
         result -= Scalar.zero
-        XCTAssertEqual(result, complex, file: file, line: line)
+        CTAssertEqual(result, complex, file: file, line: line)
     }
 
     private func testMultiplicationWithZero<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(.zero, complex * .zero, file: file, line: line)
-        XCTAssertEqual(.zero, complex .* .zero, file: file, line: line)
-        XCTAssertEqual(.zero, complex * Scalar.zero, file: file, line: line)
-        XCTAssertEqual(.zero, Scalar.zero * complex, file: file, line: line)
+        CTAssertEqual(.zero, complex * .zero, file: file, line: line)
+        CTAssertEqual(.zero, complex .* .zero, file: file, line: line)
+        CTAssertEqual(.zero, complex * Scalar.zero, file: file, line: line)
+        CTAssertEqual(.zero, Scalar.zero * complex, file: file, line: line)
 
         var result = complex
         result *= .zero
-        XCTAssertEqual(result, .zero, file: file, line: line)
+        CTAssertEqual(result, .zero, file: file, line: line)
 
         result = complex
         result .*= .zero
-        XCTAssertEqual(result, .zero, file: file, line: line)
+        CTAssertEqual(result, .zero, file: file, line: line)
 
         result = complex
         result *= Scalar.zero
-        XCTAssertEqual(result, .zero, file: file, line: line)
+        CTAssertEqual(result, .zero, file: file, line: line)
     }
 
     private func testAddition<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(lhs + rhs, result, file: file, line: line)
-        XCTAssertEqual(rhs + lhs, result, file: file, line: line)
-        XCTAssertEqual(lhs .+ rhs, result, file: file, line: line)
-        XCTAssertEqual(rhs .+ lhs, result, file: file, line: line)
+        CTAssertEqual(lhs + rhs, result, file: file, line: line)
+        CTAssertEqual(rhs + lhs, result, file: file, line: line)
+        CTAssertEqual(lhs .+ rhs, result, file: file, line: line)
+        CTAssertEqual(rhs .+ lhs, result, file: file, line: line)
 
         var complex = lhs
         complex += rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
 
         complex = rhs
         complex += lhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
 
         complex = lhs
         complex .+= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
 
         complex = rhs
         complex .+= lhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
     }
 
     private func testAddition<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(lhs + rhs, result, file: file, line: line)
-        XCTAssertEqual(rhs + lhs, result, file: file, line: line)
+        CTAssertEqual(lhs + rhs, result, file: file, line: line)
+        CTAssertEqual(rhs + lhs, result, file: file, line: line)
 
         var complex = lhs
         complex += rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
     }
 
     private func testAdditionIgnoringOverflow<Scalar>(forType: Scalar.Type, file: StaticString = #file, line: UInt = #line) where Scalar: FixedWidthInteger {
@@ -465,25 +465,25 @@ class ComplexArithmeticTests: XCTestCase {
         var rhs = Complex<Scalar>(real: Scalar.max, imaginary: 0)
         var result = lhs.addingReportingOverflow(rhs)
 
-        XCTAssertTrue(result.overflow, file: file, line: line)
-        XCTAssertEqual(result.partialValue.real, Scalar.max - 1, file: file, line: line)
-        XCTAssertEqual(result.partialValue.imaginary, 0, file: file, line: line)
+        CTAssertTrue(result.overflow, file: file, line: line)
+        CTAssertEqual(result.partialValue.real, Scalar.max - 1, file: file, line: line)
+        CTAssertEqual(result.partialValue.imaginary, 0, file: file, line: line)
 
         lhs = Complex<Scalar>(real: 0, imaginary: Scalar.max)
         rhs = Complex<Scalar>(real: 0, imaginary: Scalar.max)
         result = lhs.addingReportingOverflow(rhs)
 
-        XCTAssertTrue(result.overflow, file: file, line: line)
-        XCTAssertEqual(result.partialValue.real, 0, file: file, line: line)
-        XCTAssertEqual(result.partialValue.imaginary, Scalar.max - 1, file: file, line: line)
+        CTAssertTrue(result.overflow, file: file, line: line)
+        CTAssertEqual(result.partialValue.real, 0, file: file, line: line)
+        CTAssertEqual(result.partialValue.imaginary, Scalar.max - 1, file: file, line: line)
 
         lhs = Complex<Scalar>(real: Scalar.max, imaginary: Scalar.max)
         rhs = Complex<Scalar>(real: Scalar.max, imaginary: Scalar.max)
         result = lhs.addingReportingOverflow(rhs)
 
-        XCTAssertTrue(result.overflow, file: file, line: line)
-        XCTAssertEqual(result.partialValue.real, Scalar.max - 1, file: file, line: line)
-        XCTAssertEqual(result.partialValue.imaginary, Scalar.max - 1, file: file, line: line)
+        CTAssertTrue(result.overflow, file: file, line: line)
+        CTAssertEqual(result.partialValue.real, Scalar.max - 1, file: file, line: line)
+        CTAssertEqual(result.partialValue.imaginary, Scalar.max - 1, file: file, line: line)
     }
 
     private func testOverflowingAddition<Scalar>(forType: Scalar.Type, file: StaticString = #file, line: UInt = #line) where Scalar: FixedWidthInteger, Scalar: SignedInteger {
@@ -491,78 +491,78 @@ class ComplexArithmeticTests: XCTestCase {
         var rhs = Complex<Scalar>(real: Scalar.max, imaginary: 0)
         var result = lhs.addingReportingOverflow(rhs)
 
-        XCTAssertTrue(result.overflow, file: file, line: line)
-        XCTAssertEqual(result.partialValue.real, -2, file: file, line: line)
-        XCTAssertEqual(result.partialValue.imaginary, 0, file: file, line: line)
+        CTAssertTrue(result.overflow, file: file, line: line)
+        CTAssertEqual(result.partialValue.real, -2, file: file, line: line)
+        CTAssertEqual(result.partialValue.imaginary, 0, file: file, line: line)
 
         lhs = Complex<Scalar>(real: 0, imaginary: Scalar.max)
         rhs = Complex<Scalar>(real: 0, imaginary: Scalar.max)
         result = lhs.addingReportingOverflow(rhs)
 
-        XCTAssertTrue(result.overflow, file: file, line: line)
-        XCTAssertEqual(result.partialValue.real, 0, file: file, line: line)
-        XCTAssertEqual(result.partialValue.imaginary, -2, file: file, line: line)
+        CTAssertTrue(result.overflow, file: file, line: line)
+        CTAssertEqual(result.partialValue.real, 0, file: file, line: line)
+        CTAssertEqual(result.partialValue.imaginary, -2, file: file, line: line)
 
         lhs = Complex<Scalar>(real: Scalar.max, imaginary: Scalar.max)
         rhs = Complex<Scalar>(real: Scalar.max, imaginary: Scalar.max)
         result = lhs.addingReportingOverflow(rhs)
 
-        XCTAssertTrue(result.overflow, file: file, line: line)
-        XCTAssertEqual(result.partialValue.real, -2, file: file, line: line)
-        XCTAssertEqual(result.partialValue.imaginary, -2, file: file, line: line)
+        CTAssertTrue(result.overflow, file: file, line: line)
+        CTAssertEqual(result.partialValue.real, -2, file: file, line: line)
+        CTAssertEqual(result.partialValue.imaginary, -2, file: file, line: line)
     }
 
     private func testSubtraction<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(lhs - rhs, result, file: file, line: line)
-        XCTAssertEqual(lhs .- rhs, result, file: file, line: line)
+        CTAssertEqual(lhs - rhs, result, file: file, line: line)
+        CTAssertEqual(lhs .- rhs, result, file: file, line: line)
 
         var complex = lhs
         complex -= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
 
         complex = lhs
         complex .-= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
     }
 
     private func testSubtraction<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
-        XCTAssertEqual(lhs - rhs, result, file: file, line: line)
-        XCTAssertEqual(rhs - lhs, -result, file: file, line: line)
-        XCTAssertEqual(lhs .- rhs, result, file: file, line: line)
-        XCTAssertEqual(rhs .- lhs, -result, file: file, line: line)
+        CTAssertEqual(lhs - rhs, result, file: file, line: line)
+        CTAssertEqual(rhs - lhs, -result, file: file, line: line)
+        CTAssertEqual(lhs .- rhs, result, file: file, line: line)
+        CTAssertEqual(rhs .- lhs, -result, file: file, line: line)
 
         var complex = lhs
         complex -= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
 
         complex = rhs
         complex -= lhs
-        XCTAssertEqual(complex, -result, file: file, line: line)
+        CTAssertEqual(complex, -result, file: file, line: line)
 
         complex = lhs
         complex .-= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
 
         complex = rhs
         complex .-= lhs
-        XCTAssertEqual(complex, -result, file: file, line: line)
+        CTAssertEqual(complex, -result, file: file, line: line)
     }
 
     private func testSubtraction<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(lhs - rhs, result, file: file, line: line)
+        CTAssertEqual(lhs - rhs, result, file: file, line: line)
 
         var complex = lhs
         complex -= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
     }
 
     private func testSubtraction<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
-        XCTAssertEqual(lhs - rhs, result, file: file, line: line)
-        XCTAssertEqual(rhs - lhs, -result, file: file, line: line)
+        CTAssertEqual(lhs - rhs, result, file: file, line: line)
+        CTAssertEqual(rhs - lhs, -result, file: file, line: line)
 
         var complex = lhs
         complex -= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
     }
 
     private func testSubtractionIgnoringOverflow<Scalar>(forType: Scalar.Type, file: StaticString = #file, line: UInt = #line) where Scalar: FixedWidthInteger {
@@ -611,38 +611,38 @@ class ComplexArithmeticTests: XCTestCase {
         var rhs = Complex<Scalar>(real: Scalar.max, imaginary: 0)
         var result = lhs.subtractingReportingOverflow(rhs)
 
-        XCTAssertTrue(result.overflow, file: file, line: line)
-        XCTAssertEqual(result.partialValue.real, 1, file: file, line: line)
-        XCTAssertEqual(result.partialValue.imaginary, 0, file: file, line: line)
+        CTAssertTrue(result.overflow, file: file, line: line)
+        CTAssertEqual(result.partialValue.real, 1, file: file, line: line)
+        CTAssertEqual(result.partialValue.imaginary, 0, file: file, line: line)
 
         lhs = Complex<Scalar>(real: 0, imaginary: Scalar.min)
         rhs = Complex<Scalar>(real: 0, imaginary: Scalar.max)
         result = lhs.subtractingReportingOverflow(rhs)
 
-        XCTAssertTrue(result.overflow, file: file, line: line)
-        XCTAssertEqual(result.partialValue.real, 0, file: file, line: line)
-        XCTAssertEqual(result.partialValue.imaginary, 1, file: file, line: line)
+        CTAssertTrue(result.overflow, file: file, line: line)
+        CTAssertEqual(result.partialValue.real, 0, file: file, line: line)
+        CTAssertEqual(result.partialValue.imaginary, 1, file: file, line: line)
 
         lhs = Complex<Scalar>(real: Scalar.min, imaginary: Scalar.min)
         rhs = Complex<Scalar>(real: Scalar.max, imaginary: Scalar.max)
         result = lhs.subtractingReportingOverflow(rhs)
 
-        XCTAssertTrue(result.overflow, file: file, line: line)
-        XCTAssertEqual(result.partialValue.real, 1, file: file, line: line)
-        XCTAssertEqual(result.partialValue.imaginary, 1, file: file, line: line)
+        CTAssertTrue(result.overflow, file: file, line: line)
+        CTAssertEqual(result.partialValue.real, 1, file: file, line: line)
+        CTAssertEqual(result.partialValue.imaginary, 1, file: file, line: line)
     }
 
     private func testMultiplication<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(lhs * rhs, result, file: file, line: line)
-        XCTAssertEqual(rhs * lhs, result, file: file, line: line)
+        CTAssertEqual(lhs * rhs, result, file: file, line: line)
+        CTAssertEqual(rhs * lhs, result, file: file, line: line)
 
         var complex = lhs
         complex *= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
 
         complex = rhs
         complex *= lhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
     }
 
     private func testMultiplicationIgnoringOverflow<Scalar>(forType: Scalar.Type, file: StaticString = #file, line: UInt = #line) where Scalar: FixedWidthInteger {
@@ -676,23 +676,23 @@ class ComplexArithmeticTests: XCTestCase {
 
     private func testMultiplication<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, file: StaticString = #file, line: UInt = #line) {
         let result = Complex(real: lhs.real * rhs, imaginary: lhs.imaginary * rhs)
-        XCTAssertEqual(lhs * rhs, result, file: file, line: line)
-        XCTAssertEqual(rhs * lhs, result, file: file, line: line)
+        CTAssertEqual(lhs * rhs, result, file: file, line: line)
+        CTAssertEqual(rhs * lhs, result, file: file, line: line)
 
         var complex = lhs
         complex *= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
     }
 
     private func testComponentwiseMultiplication<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
         var result = lhs .* rhs
-        XCTAssertEqual(result.real, lhs.real * rhs.real, file: file, line: line)
-        XCTAssertEqual(result.imaginary, lhs.imaginary * rhs.imaginary, file: file, line: line)
+        CTAssertEqual(result.real, lhs.real * rhs.real, file: file, line: line)
+        CTAssertEqual(result.imaginary, lhs.imaginary * rhs.imaginary, file: file, line: line)
 
         result = lhs
         result .*= rhs
-        XCTAssertEqual(result.real, lhs.real * rhs.real, file: file, line: line)
-        XCTAssertEqual(result.imaginary, lhs.imaginary * rhs.imaginary, file: file, line: line)
+        CTAssertEqual(result.real, lhs.real * rhs.real, file: file, line: line)
+        CTAssertEqual(result.imaginary, lhs.imaginary * rhs.imaginary, file: file, line: line)
     }
 
     private func testComponentwiseOverflowingMultiplication<Scalar>(forType: Scalar.Type, file: StaticString = #file, line: UInt = #line) where Scalar: FixedWidthInteger, Scalar: UnsignedInteger {
@@ -700,31 +700,31 @@ class ComplexArithmeticTests: XCTestCase {
         var rhs = Complex<Scalar>(real: 2, imaginary: 2)
 
         let fullWidth = lhs.componentwiseMultipliedFullWidth(by: rhs)
-        XCTAssertEqual(fullWidth.high.real, 1, file: file, line: line)
-        XCTAssertEqual(fullWidth.high.imaginary, 1, file: file, line: line)
-        XCTAssertEqual(fullWidth.low.real, Scalar.Magnitude.max - 1, file: file, line: line)
-        XCTAssertEqual(fullWidth.low.imaginary, Scalar.Magnitude.max - 1, file: file, line: line)
+        CTAssertEqual(fullWidth.high.real, 1, file: file, line: line)
+        CTAssertEqual(fullWidth.high.imaginary, 1, file: file, line: line)
+        CTAssertEqual(fullWidth.low.real, Scalar.Magnitude.max - 1, file: file, line: line)
+        CTAssertEqual(fullWidth.low.imaginary, Scalar.Magnitude.max - 1, file: file, line: line)
 
         var overflow = lhs.componentwiseMultipliedReportingOverflow(by: rhs)
-        XCTAssertTrue(overflow.overflow, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.real, Scalar.max - 1, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.imaginary, Scalar.max - 1, file: file, line: line)
+        CTAssertTrue(overflow.overflow, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.real, Scalar.max - 1, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.imaginary, Scalar.max - 1, file: file, line: line)
 
         lhs = Complex<Scalar>(real: Scalar.max, imaginary: 0)
         rhs = Complex<Scalar>(real: 2, imaginary: 0)
         overflow = lhs.componentwiseMultipliedReportingOverflow(by: rhs)
 
-        XCTAssertTrue(overflow.overflow, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.real, Scalar.max - 1, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.imaginary, 0, file: file, line: line)
+        CTAssertTrue(overflow.overflow, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.real, Scalar.max - 1, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.imaginary, 0, file: file, line: line)
 
         lhs = Complex<Scalar>(real: 0, imaginary: Scalar.max)
         rhs = Complex<Scalar>(real: 0, imaginary: 2)
         overflow = lhs.componentwiseMultipliedReportingOverflow(by: rhs)
 
-        XCTAssertTrue(overflow.overflow, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.real, 0, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.imaginary, Scalar.max - 1, file: file, line: line)
+        CTAssertTrue(overflow.overflow, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.real, 0, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.imaginary, Scalar.max - 1, file: file, line: line)
     }
 
     private func testComponentwiseOverflowingMultiplication<Scalar>(forType: Scalar.Type, file: StaticString = #file, line: UInt = #line) where Scalar: FixedWidthInteger, Scalar: SignedInteger {
@@ -732,95 +732,95 @@ class ComplexArithmeticTests: XCTestCase {
         var rhs = Complex<Scalar>(real: 4, imaginary: 4)
 
         let fullWidth = lhs.componentwiseMultipliedFullWidth(by: rhs)
-        XCTAssertEqual(fullWidth.high.real, 1, file: file, line: line)
-        XCTAssertEqual(fullWidth.high.imaginary, 1, file: file, line: line)
-        XCTAssertEqual(fullWidth.low.real, Scalar.Magnitude.max - 3, file: file, line: line)
-        XCTAssertEqual(fullWidth.low.imaginary, Scalar.Magnitude.max - 3, file: file, line: line)
+        CTAssertEqual(fullWidth.high.real, 1, file: file, line: line)
+        CTAssertEqual(fullWidth.high.imaginary, 1, file: file, line: line)
+        CTAssertEqual(fullWidth.low.real, Scalar.Magnitude.max - 3, file: file, line: line)
+        CTAssertEqual(fullWidth.low.imaginary, Scalar.Magnitude.max - 3, file: file, line: line)
 
         var overflow = lhs.componentwiseMultipliedReportingOverflow(by: rhs)
-        XCTAssertTrue(overflow.overflow, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.real, -4, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.imaginary, -4, file: file, line: line)
+        CTAssertTrue(overflow.overflow, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.real, -4, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.imaginary, -4, file: file, line: line)
 
         lhs = Complex<Scalar>(real: Scalar.max, imaginary: 0)
         rhs = Complex<Scalar>(real: 4, imaginary: 0)
         overflow = lhs.componentwiseMultipliedReportingOverflow(by: rhs)
 
-        XCTAssertTrue(overflow.overflow, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.real, -4, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.imaginary, 0, file: file, line: line)
+        CTAssertTrue(overflow.overflow, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.real, -4, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.imaginary, 0, file: file, line: line)
 
         lhs = Complex<Scalar>(real: 0, imaginary: Scalar.max)
         rhs = Complex<Scalar>(real: 0, imaginary: 4)
         overflow = lhs.componentwiseMultipliedReportingOverflow(by: rhs)
 
-        XCTAssertTrue(overflow.overflow, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.real, 0, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.imaginary, -4, file: file, line: line)
+        CTAssertTrue(overflow.overflow, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.real, 0, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.imaginary, -4, file: file, line: line)
     }
 
     private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryInteger {
-        XCTAssertEqual(lhs / rhs, result, file: file, line: line)
+        CTAssertEqual(lhs / rhs, result, file: file, line: line)
 
         var complex = lhs
         complex /= rhs
-        XCTAssertEqual(complex, result, file: file, line: line)
+        CTAssertEqual(complex, result, file: file, line: line)
     }
 
     private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, _ result: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint {
-        XCTAssertTrue((lhs / rhs - result).modulus < 0.0001, file: file, line: line)
+        CTAssertTrue((lhs / rhs - result).modulus < 0.0001, file: file, line: line)
 
         var complex = lhs
         complex /= rhs
-        XCTAssertTrue((complex - result).modulus < 0.0001, file: file, line: line)
+        CTAssertTrue((complex - result).modulus < 0.0001, file: file, line: line)
     }
 
     private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryInteger {
-        XCTAssertEqual(lhs / rhs, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+        CTAssertEqual(lhs / rhs, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
 
         var complex = lhs
         complex /= rhs
-        XCTAssertEqual(complex, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+        CTAssertEqual(complex, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
     }
 
     private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: SignedInteger {
-        XCTAssertEqual(lhs / rhs, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
-        XCTAssertEqual(rhs / lhs, (Complex(real: rhs, imaginary: 0) / lhs), file: file, line: line)
+        CTAssertEqual(lhs / rhs, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+        CTAssertEqual(rhs / lhs, (Complex(real: rhs, imaginary: 0) / lhs), file: file, line: line)
 
         var complex = lhs
         complex /= rhs
-        XCTAssertEqual(complex, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+        CTAssertEqual(complex, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
     }
 
     private func testDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint {
-        XCTAssertEqual(lhs / rhs, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
-        XCTAssertEqual(rhs / lhs, (Complex(real: rhs, imaginary: 0) / lhs), file: file, line: line)
+        CTAssertEqual(lhs / rhs, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+        CTAssertEqual(rhs / lhs, (Complex(real: rhs, imaginary: 0) / lhs), file: file, line: line)
 
         var complex = lhs
         complex /= rhs
-        XCTAssertEqual(complex, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
+        CTAssertEqual(complex, Complex(real: lhs.real / rhs, imaginary: lhs.imaginary / rhs), file: file, line: line)
     }
 
     private func testComponentwiseDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryInteger {
         var result = lhs ./ rhs
-        XCTAssertEqual(result.real, lhs.real / rhs.real, file: file, line: line)
-        XCTAssertEqual(result.imaginary, lhs.imaginary / rhs.imaginary, file: file, line: line)
+        CTAssertEqual(result.real, lhs.real / rhs.real, file: file, line: line)
+        CTAssertEqual(result.imaginary, lhs.imaginary / rhs.imaginary, file: file, line: line)
 
         result = lhs
         result ./= rhs
-        XCTAssertEqual(result.real, lhs.real / rhs.real, file: file, line: line)
-        XCTAssertEqual(result.imaginary, lhs.imaginary / rhs.imaginary, file: file, line: line)
+        CTAssertEqual(result.real, lhs.real / rhs.real, file: file, line: line)
+        CTAssertEqual(result.imaginary, lhs.imaginary / rhs.imaginary, file: file, line: line)
     }
 
     private func testComponentwiseDivision<Scalar>(_ lhs: Complex<Scalar>, _ rhs: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: FloatingPoint {
         var result = lhs ./ rhs
-        XCTAssertEqual(result.real, lhs.real / rhs.real, file: file, line: line)
-        XCTAssertEqual(result.imaginary, lhs.imaginary / rhs.imaginary, file: file, line: line)
+        CTAssertEqual(result.real, lhs.real / rhs.real, file: file, line: line)
+        CTAssertEqual(result.imaginary, lhs.imaginary / rhs.imaginary, file: file, line: line)
 
         result = lhs
         result ./= rhs
-        XCTAssertEqual(result.real, lhs.real / rhs.real, file: file, line: line)
-        XCTAssertEqual(result.imaginary, lhs.imaginary / rhs.imaginary, file: file, line: line)
+        CTAssertEqual(result.real, lhs.real / rhs.real, file: file, line: line)
+        CTAssertEqual(result.imaginary, lhs.imaginary / rhs.imaginary, file: file, line: line)
     }
 
     private func testComponentwiseOverflowingDivision<Scalar>(forType: Scalar.Type, file: StaticString = #file, line: UInt = #line) where Scalar: FixedWidthInteger {
@@ -828,25 +828,25 @@ class ComplexArithmeticTests: XCTestCase {
         var rhs = Complex<Scalar>(real: 0, imaginary: 0)
 
         let fullWidth = lhs.componentwiseDividingFullWidth((high: Complex<Scalar>(real: 1, imaginary: 1), low: Complex<Scalar.Magnitude>.zero))
-        XCTAssertEqual(fullWidth.quotient.real, Scalar.isSigned ? 2 : 1, file: file, line: line)
-        XCTAssertEqual(fullWidth.quotient.imaginary, Scalar.isSigned ? 2 : 1, file: file, line: line)
-        XCTAssertEqual(fullWidth.remainder.real, Scalar.isSigned ? 2 : 1, file: file, line: line)
-        XCTAssertEqual(fullWidth.remainder.imaginary, Scalar.isSigned ? 2 : 1, file: file, line: line)
+        CTAssertEqual(fullWidth.quotient.real, Scalar.isSigned ? 2 : 1, file: file, line: line)
+        CTAssertEqual(fullWidth.quotient.imaginary, Scalar.isSigned ? 2 : 1, file: file, line: line)
+        CTAssertEqual(fullWidth.remainder.real, Scalar.isSigned ? 2 : 1, file: file, line: line)
+        CTAssertEqual(fullWidth.remainder.imaginary, Scalar.isSigned ? 2 : 1, file: file, line: line)
 
         var overflow = lhs.componentwiseDividedReportingOverflow(by: rhs)
-        XCTAssertTrue(overflow.overflow, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue, lhs, file: file, line: line)
+        CTAssertTrue(overflow.overflow, file: file, line: line)
+        CTAssertEqual(overflow.partialValue, lhs, file: file, line: line)
 
         rhs = Complex<Scalar>(real: 0, imaginary: Scalar.max)
         overflow = lhs.componentwiseDividedReportingOverflow(by: rhs)
-        XCTAssertTrue(overflow.overflow, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.real, lhs.real, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.imaginary, 1, file: file, line: line)
+        CTAssertTrue(overflow.overflow, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.real, lhs.real, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.imaginary, 1, file: file, line: line)
 
         rhs = Complex<Scalar>(real: Scalar.max, imaginary: 0)
         overflow = lhs.componentwiseDividedReportingOverflow(by: rhs)
-        XCTAssertTrue(overflow.overflow, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.real, 1, file: file, line: line)
-        XCTAssertEqual(overflow.partialValue.imaginary, lhs.imaginary, file: file, line: line)
+        CTAssertTrue(overflow.overflow, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.real, 1, file: file, line: line)
+        CTAssertEqual(overflow.partialValue.imaginary, lhs.imaginary, file: file, line: line)
     }
 }

--- a/Tests/ComplexTests/ComplexTests.swift
+++ b/Tests/ComplexTests/ComplexTests.swift
@@ -151,10 +151,10 @@ class ComplexTests: XCTestCase {
     }
 
     func testAdditiveArithmeticProtocolRequirements() {
-        XCTAssertEqual(Complex<Half>.zero, Complex(real: 0.0, imaginary: 0.0))
-        XCTAssertEqual(Complex<Float>.zero, Complex(real: 0.0, imaginary: 0.0))
-        XCTAssertEqual(Complex<Double>.zero, Complex(real: 0.0, imaginary: 0.0))
-        XCTAssertEqual(Complex<Float80>.zero, Complex(real: 0.0, imaginary: 0.0))
+        CTAssertEqual(Complex<Half>.zero, Complex(real: 0.0, imaginary: 0.0))
+        CTAssertEqual(Complex<Float>.zero, Complex(real: 0.0, imaginary: 0.0))
+        CTAssertEqual(Complex<Double>.zero, Complex(real: 0.0, imaginary: 0.0))
+        CTAssertEqual(Complex<Float80>.zero, Complex(real: 0.0, imaginary: 0.0))
 
         do {
             let lhs = Complex<Half>(real: 1.0, imaginary: 2.0)
@@ -162,16 +162,16 @@ class ComplexTests: XCTestCase {
             var value = lhs
             value += rhs
 
-            XCTAssertEqual(lhs + rhs, Complex(real: 4.0, imaginary: 6.0))
-            XCTAssertEqual(value, Complex(real: 4.0, imaginary: 6.0))
-            XCTAssertEqual(value, lhs + rhs)
+            CTAssertEqual(lhs + rhs, Complex(real: 4.0, imaginary: 6.0))
+            CTAssertEqual(value, Complex(real: 4.0, imaginary: 6.0))
+            CTAssertEqual(value, lhs + rhs)
 
             value = lhs
             value -= rhs
 
-            XCTAssertEqual(lhs - rhs, Complex(real: -2.0, imaginary: -2.0))
-            XCTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
-            XCTAssertEqual(value, lhs - rhs)
+            CTAssertEqual(lhs - rhs, Complex(real: -2.0, imaginary: -2.0))
+            CTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
+            CTAssertEqual(value, lhs - rhs)
         }
         do {
             let lhs = Complex<Float>(real: 1.0, imaginary: 2.0)
@@ -179,16 +179,16 @@ class ComplexTests: XCTestCase {
             var value = lhs
             value += rhs
 
-            XCTAssertEqual(lhs + rhs, Complex(real: 4.0, imaginary: 6.0))
-            XCTAssertEqual(value, Complex(real: 4.0, imaginary: 6.0))
-            XCTAssertEqual(value, lhs + rhs)
+            CTAssertEqual(lhs + rhs, Complex(real: 4.0, imaginary: 6.0))
+            CTAssertEqual(value, Complex(real: 4.0, imaginary: 6.0))
+            CTAssertEqual(value, lhs + rhs)
 
             value = lhs
             value -= rhs
 
-            XCTAssertEqual(lhs - rhs, Complex(real: -2.0, imaginary: -2.0))
-            XCTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
-            XCTAssertEqual(value, lhs - rhs)
+            CTAssertEqual(lhs - rhs, Complex(real: -2.0, imaginary: -2.0))
+            CTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
+            CTAssertEqual(value, lhs - rhs)
         }
         do {
             let lhs = Complex<Double>(real: 1.0, imaginary: 2.0)
@@ -196,16 +196,16 @@ class ComplexTests: XCTestCase {
             var value = lhs
             value += rhs
 
-            XCTAssertEqual(lhs + rhs, Complex(real: 4.0, imaginary: 6.0))
-            XCTAssertEqual(value, Complex(real: 4.0, imaginary: 6.0))
-            XCTAssertEqual(value, lhs + rhs)
+            CTAssertEqual(lhs + rhs, Complex(real: 4.0, imaginary: 6.0))
+            CTAssertEqual(value, Complex(real: 4.0, imaginary: 6.0))
+            CTAssertEqual(value, lhs + rhs)
 
             value = lhs
             value -= rhs
 
-            XCTAssertEqual(lhs - rhs, Complex(real: -2.0, imaginary: -2.0))
-            XCTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
-            XCTAssertEqual(value, lhs - rhs)
+            CTAssertEqual(lhs - rhs, Complex(real: -2.0, imaginary: -2.0))
+            CTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
+            CTAssertEqual(value, lhs - rhs)
         }
         do {
             let lhs = Complex<Float80>(real: 1.0, imaginary: 2.0)
@@ -213,16 +213,16 @@ class ComplexTests: XCTestCase {
             var value = lhs
             value += rhs
 
-            XCTAssertEqual(lhs + rhs, Complex(real: 4.0, imaginary: 6.0))
-            XCTAssertEqual(value, Complex(real: 4.0, imaginary: 6.0))
-            XCTAssertEqual(value, lhs + rhs)
+            CTAssertEqual(lhs + rhs, Complex(real: 4.0, imaginary: 6.0))
+            CTAssertEqual(value, Complex(real: 4.0, imaginary: 6.0))
+            CTAssertEqual(value, lhs + rhs)
 
             value = lhs
             value -= rhs
 
-            XCTAssertEqual(lhs - rhs, Complex(real: -2.0, imaginary: -2.0))
-            XCTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
-            XCTAssertEqual(value, lhs - rhs)
+            CTAssertEqual(lhs - rhs, Complex(real: -2.0, imaginary: -2.0))
+            CTAssertEqual(value, Complex(real: -2.0, imaginary: -2.0))
+            CTAssertEqual(value, lhs - rhs)
         }
     }
 
@@ -230,86 +230,86 @@ class ComplexTests: XCTestCase {
 
     private func testInitialization<Scalar>(real: Scalar, imaginary: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryInteger {
         let complex0 = Complex<Scalar>()
-        XCTAssertEqual(complex0.real, 0, file: file, line: line)
-        XCTAssertEqual(complex0.imaginary, 0, file: file, line: line)
+        CTAssertEqual(complex0.real, 0)
+        CTAssertEqual(complex0.imaginary, 0)
 
         let complex1 = Complex<Scalar>(real: real, imaginary: imaginary)
-        XCTAssertEqual(complex1.real, real, file: file, line: line)
-        XCTAssertEqual(complex1.imaginary, imaginary, file: file, line: line)
+        CTAssertEqual(complex1.real, real)
+        CTAssertEqual(complex1.imaginary, imaginary)
 
         let complex2 = Complex<Scalar>(complex1)
-        XCTAssertEqual(complex2.real, real, file: file, line: line)
-        XCTAssertEqual(complex2.imaginary, imaginary, file: file, line: line)
+        CTAssertEqual(complex2.real, real)
+        CTAssertEqual(complex2.imaginary, imaginary)
 
         let complex3 = Complex<Int64>(real: real, imaginary: imaginary)
-        XCTAssertEqual(complex3.real, Int64(real), file: file, line: line)
-        XCTAssertEqual(complex3.imaginary, Int64(imaginary), file: file, line: line)
+        CTAssertEqual(complex3.real, Int64(real))
+        CTAssertEqual(complex3.imaginary, Int64(imaginary))
 
         let complex4 = Complex<Int64>(complex1)
-        XCTAssertEqual(complex4.real, Int64(real), file: file, line: line)
-        XCTAssertEqual(complex4.imaginary, Int64(imaginary), file: file, line: line)
+        CTAssertEqual(complex4.real, Int64(real))
+        CTAssertEqual(complex4.imaginary, Int64(imaginary))
 
         let complex5 = Complex<Float80>(real: real, imaginary: imaginary)
-        XCTAssertEqual(complex5.real, Float80(real), file: file, line: line)
-        XCTAssertEqual(complex5.imaginary, Float80(imaginary), file: file, line: line)
+        CTAssertEqual(complex5.real, Float80(real))
+        CTAssertEqual(complex5.imaginary, Float80(imaginary))
 
         let complex6 = Complex<Float80>(complex1)
-        XCTAssertEqual(complex6.real, Float80(real), file: file, line: line)
-        XCTAssertEqual(complex6.imaginary, Float80(imaginary), file: file, line: line)
+        CTAssertEqual(complex6.real, Float80(real))
+        CTAssertEqual(complex6.imaginary, Float80(imaginary))
 
         let complex7: Complex<Scalar> = []
-        XCTAssertEqual(complex7.real, 0, file: file, line: line)
-        XCTAssertEqual(complex7.imaginary, 0, file: file, line: line)
+        CTAssertEqual(complex7.real, 0)
+        CTAssertEqual(complex7.imaginary, 0)
 
         let complex8: Complex<Scalar> = [real]
-        XCTAssertEqual(complex8.real, real, file: file, line: line)
-        XCTAssertEqual(complex8.imaginary, 0, file: file, line: line)
+        CTAssertEqual(complex8.real, real)
+        CTAssertEqual(complex8.imaginary, 0)
 
         let complex9: Complex<Scalar> = [real, imaginary]
-        XCTAssertEqual(complex9.real, real, file: file, line: line)
-        XCTAssertEqual(complex9.imaginary, imaginary, file: file, line: line)
+        CTAssertEqual(complex9.real, real)
+        CTAssertEqual(complex9.imaginary, imaginary)
     }
 
     private func testInitialization<Scalar>(real: Scalar, imaginary: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint {
         let complex0 = Complex<Scalar>()
-        XCTAssertEqual(complex0.real, 0.0, file: file, line: line)
-        XCTAssertEqual(complex0.imaginary, 0.0, file: file, line: line)
+        CTAssertEqual(complex0.real, 0.0)
+        CTAssertEqual(complex0.imaginary, 0.0)
 
         let complex1 = Complex<Scalar>(real: real, imaginary: imaginary)
-        XCTAssertEqual(complex1.real, real, file: file, line: line)
-        XCTAssertEqual(complex1.imaginary, imaginary, file: file, line: line)
+        CTAssertEqual(complex1.real, real)
+        CTAssertEqual(complex1.imaginary, imaginary)
 
         let complex2 = Complex<Scalar>(complex1)
-        XCTAssertEqual(complex2.real, real, file: file, line: line)
-        XCTAssertEqual(complex2.imaginary, imaginary, file: file, line: line)
+        CTAssertEqual(complex2.real, real)
+        CTAssertEqual(complex2.imaginary, imaginary)
 
         let complex3 = Complex<Int64>(real: real, imaginary: imaginary)
-        XCTAssertEqual(complex3.real, Int64(real), file: file, line: line)
-        XCTAssertEqual(complex3.imaginary, Int64(imaginary), file: file, line: line)
+        CTAssertEqual(complex3.real, Int64(real))
+        CTAssertEqual(complex3.imaginary, Int64(imaginary))
 
         let complex4 = Complex<Int64>(complex1)
-        XCTAssertEqual(complex4.real, Int64(real), file: file, line: line)
-        XCTAssertEqual(complex4.imaginary, Int64(imaginary), file: file, line: line)
+        CTAssertEqual(complex4.real, Int64(real))
+        CTAssertEqual(complex4.imaginary, Int64(imaginary))
 
         let complex5 = Complex<Float80>(real: real, imaginary: imaginary)
-        XCTAssertEqual(complex5.real, Float80(real), file: file, line: line)
-        XCTAssertEqual(complex5.imaginary, Float80(imaginary), file: file, line: line)
+        CTAssertEqual(complex5.real, Float80(real))
+        CTAssertEqual(complex5.imaginary, Float80(imaginary))
 
         let complex6 = Complex<Float80>(complex1)
-        XCTAssertEqual(complex6.real, Float80(real), file: file, line: line)
-        XCTAssertEqual(complex6.imaginary, Float80(imaginary), file: file, line: line)
+        CTAssertEqual(complex6.real, Float80(real))
+        CTAssertEqual(complex6.imaginary, Float80(imaginary))
 
         let complex7: Complex<Scalar> = []
-        XCTAssertEqual(complex7.real, 0.0, file: file, line: line)
-        XCTAssertEqual(complex7.imaginary, 0.0, file: file, line: line)
+        CTAssertEqual(complex7.real, 0.0)
+        CTAssertEqual(complex7.imaginary, 0.0)
 
         let complex8: Complex<Scalar> = [real]
-        XCTAssertEqual(complex8.real, real, file: file, line: line)
-        XCTAssertEqual(complex8.imaginary, 0.0, file: file, line: line)
+        CTAssertEqual(complex8.real, real)
+        CTAssertEqual(complex8.imaginary, 0.0)
 
         let complex9: Complex<Scalar> = [real, imaginary]
-        XCTAssertEqual(complex9.real, real, file: file, line: line)
-        XCTAssertEqual(complex9.imaginary, imaginary, file: file, line: line)
+        CTAssertEqual(complex9.real, real)
+        CTAssertEqual(complex9.imaginary, imaginary)
     }
 
     private func testRandomFactoryMethods<Scalar>(lowerBound: Scalar, upperBound: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: FixedWidthInteger {
@@ -318,20 +318,20 @@ class ComplexTests: XCTestCase {
         let range: Range<Scalar> = lowerBound ..< upperBound
 
         let complex1 = Complex<Scalar>.random(in: range)
-        XCTAssertTrue(range.contains(complex1.real), file: file, line: line)
-        XCTAssertTrue(range.contains(complex1.imaginary), file: file, line: line)
+        CTAssertTrue(range.contains(complex1.real))
+        CTAssertTrue(range.contains(complex1.imaginary))
 
         let complex2 = Complex<Scalar>.random(in: range, using: &generator)
-        XCTAssertTrue(range.contains(complex2.real), file: file, line: line)
-        XCTAssertTrue(range.contains(complex2.imaginary), file: file, line: line)
+        CTAssertTrue(range.contains(complex2.real))
+        CTAssertTrue(range.contains(complex2.imaginary))
 
         let complex3 = Complex<Scalar>.random(in: closedRange)
-        XCTAssertTrue(closedRange.contains(complex3.real), file: file, line: line)
-        XCTAssertTrue(closedRange.contains(complex3.imaginary), file: file, line: line)
+        CTAssertTrue(closedRange.contains(complex3.real))
+        CTAssertTrue(closedRange.contains(complex3.imaginary))
 
         let complex4 = Complex<Scalar>.random(in: closedRange, using: &generator)
-        XCTAssertTrue(closedRange.contains(complex4.real), file: file, line: line)
-        XCTAssertTrue(closedRange.contains(complex4.imaginary), file: file, line: line)
+        CTAssertTrue(closedRange.contains(complex4.real))
+        CTAssertTrue(closedRange.contains(complex4.imaginary))
     }
 
     private func testRandomFactoryMethods<Scalar>(lowerBound: Scalar, upperBound: Scalar, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint, Scalar.RawSignificand: FixedWidthInteger {
@@ -340,20 +340,20 @@ class ComplexTests: XCTestCase {
         let range: Range<Scalar> = lowerBound ..< upperBound
 
         let complex1 = Complex<Scalar>.random(in: range)
-        XCTAssertTrue(range.contains(complex1.real), file: file, line: line)
-        XCTAssertTrue(range.contains(complex1.imaginary), file: file, line: line)
+        CTAssertTrue(range.contains(complex1.real))
+        CTAssertTrue(range.contains(complex1.imaginary))
 
         let complex2 = Complex<Scalar>.random(in: range, using: &generator)
-        XCTAssertTrue(range.contains(complex2.real), file: file, line: line)
-        XCTAssertTrue(range.contains(complex2.imaginary), file: file, line: line)
+        CTAssertTrue(range.contains(complex2.real))
+        CTAssertTrue(range.contains(complex2.imaginary))
 
         let complex3 = Complex<Scalar>.random(in: closedRange)
-        XCTAssertTrue(closedRange.contains(complex3.real), file: file, line: line)
-        XCTAssertTrue(closedRange.contains(complex3.imaginary), file: file, line: line)
+        CTAssertTrue(closedRange.contains(complex3.real))
+        CTAssertTrue(closedRange.contains(complex3.imaginary))
 
         let complex4 = Complex<Scalar>.random(in: closedRange, using: &generator)
-        XCTAssertTrue(closedRange.contains(complex4.real), file: file, line: line)
-        XCTAssertTrue(closedRange.contains(complex4.imaginary), file: file, line: line)
+        CTAssertTrue(closedRange.contains(complex4.real))
+        CTAssertTrue(closedRange.contains(complex4.imaginary))
     }
 
     private func testDescriptionMethods<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) throws where Scalar: BinaryInteger {
@@ -363,21 +363,21 @@ class ComplexTests: XCTestCase {
         let realRegex = try NSRegularExpression(pattern: "real:[ ]*\(NSRegularExpression.escapedPattern(for: "\(complex.real)"))", options: [])
         let imaginaryRegex = try NSRegularExpression(pattern: "imaginary:[ ]*\(NSRegularExpression.escapedPattern(for: "\(complex.imaginary)"))", options: [])
 
-        XCTAssertEqual(description, debugDescription, file: file, line: line)
-        XCTAssertTrue(realRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0, file: file, line: line)
-        XCTAssertTrue(imaginaryRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0, file: file, line: line)
+        CTAssertEqual(description, debugDescription)
+        CTAssertTrue(realRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0)
+        CTAssertTrue(imaginaryRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0)
 
-        XCTAssertTrue(complex.string(withNotation: .square).contains("\(complex.real)"), file: file, line: line)
-        XCTAssertTrue(complex.string(withNotation: .square).contains("\(complex.imaginary)"), file: file, line: line)
+        CTAssertTrue(complex.string(withNotation: .square).contains("\(complex.real)"))
+        CTAssertTrue(complex.string(withNotation: .square).contains("\(complex.imaginary)"))
 
-        XCTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.modulus)"), file: file, line: line)
-        XCTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.angle)"), file: file, line: line)
+        CTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.modulus)"))
+        CTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.angle)"))
 
-        XCTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.modulus)"), file: file, line: line)
-        XCTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.angle)"), file: file, line: line)
+        CTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.modulus)"))
+        CTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.angle)"))
 
-        XCTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.modulus)"), file: file, line: line)
-        XCTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.angle)"), file: file, line: line)
+        CTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.modulus)"))
+        CTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.angle)"))
     }
 
     private func testDescriptionMethods<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) throws where Scalar: BinaryFloatingPoint {
@@ -387,21 +387,21 @@ class ComplexTests: XCTestCase {
         let realRegex = try NSRegularExpression(pattern: "real:[ ]*\(NSRegularExpression.escapedPattern(for: "\(complex.real)"))", options: [])
         let imaginaryRegex = try NSRegularExpression(pattern: "imaginary:[ ]*\(NSRegularExpression.escapedPattern(for: "\(complex.imaginary)"))", options: [])
 
-        XCTAssertEqual(description, debugDescription, file: file, line: line)
-        XCTAssertTrue(realRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0, file: file, line: line)
-        XCTAssertTrue(imaginaryRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0, file: file, line: line)
+        CTAssertEqual(description, debugDescription)
+        CTAssertTrue(realRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0)
+        CTAssertTrue(imaginaryRegex.numberOfMatches(in: description, options: [], range: NSRange(location: 0, length: description.count)) > 0)
 
-        XCTAssertTrue(complex.string(withNotation: .square).contains("\(complex.real)"), file: file, line: line)
-        XCTAssertTrue(complex.string(withNotation: .square).contains("\(complex.imaginary)"), file: file, line: line)
+        CTAssertTrue(complex.string(withNotation: .square).contains("\(complex.real)"))
+        CTAssertTrue(complex.string(withNotation: .square).contains("\(complex.imaginary)"))
 
-        XCTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.modulus)"), file: file, line: line)
-        XCTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.angle)"), file: file, line: line)
+        CTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.modulus)"))
+        CTAssertTrue(complex.string(withNotation: .trigonometric).contains("\(complex.angle)"))
 
-        XCTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.modulus)"), file: file, line: line)
-        XCTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.angle)"), file: file, line: line)
+        CTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.modulus)"))
+        CTAssertTrue(complex.string(withNotation: .euler).contains("\(complex.angle)"))
 
-        XCTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.modulus)"), file: file, line: line)
-        XCTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.angle)"), file: file, line: line)
+        CTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.modulus)"))
+        CTAssertTrue(complex.string(withNotation: .angle).contains("\(complex.angle)"))
     }
 
     private func testHashing<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: Hashable {
@@ -414,72 +414,72 @@ class ComplexTests: XCTestCase {
         hasher.combine(complex.imaginary)
         let value2 = hasher.finalize()
 
-        XCTAssertEqual(value1, value2, file: file, line: line)
+        CTAssertEqual(value1, value2)
     }
 
     private func testRounding<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: FloatingPoint {
-        XCTAssertEqual(complex.rounded(), Complex(real: complex.real.rounded(), imaginary: complex.imaginary.rounded()), file: file, line: line)
+        CTAssertEqual(complex.rounded(), Complex(real: complex.real.rounded(), imaginary: complex.imaginary.rounded()))
 
         var rounded = complex
         rounded.round()
-        XCTAssertEqual(rounded, complex.rounded(), file: file, line: line)
+        CTAssertEqual(rounded, complex.rounded())
 
         for rule in [FloatingPointRoundingRule.toNearestOrAwayFromZero, .toNearestOrEven, .up, .down, .towardZero, .awayFromZero] {
-            XCTAssertEqual(complex.rounded(rule), Complex(real: complex.real.rounded(rule), imaginary: complex.imaginary.rounded(rule)), file: file, line: line)
+            CTAssertEqual(complex.rounded(rule), Complex(real: complex.real.rounded(rule), imaginary: complex.imaginary.rounded(rule)))
 
             var rounded = complex
             rounded.round(rule)
-            XCTAssertEqual(rounded, complex.rounded(rule), file: file, line: line)
+            CTAssertEqual(rounded, complex.rounded(rule))
         }
     }
 
     private func testConjugateMethods<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
         var conjugate = complex.conjugate()
-        XCTAssertEqual(complex.real, conjugate.real, file: file, line: line)
-        XCTAssertEqual(complex.imaginary, -conjugate.imaginary, file: file, line: line)
+        CTAssertEqual(complex.real, conjugate.real)
+        CTAssertEqual(complex.imaginary, -conjugate.imaginary)
 
         conjugate = ~complex
-        XCTAssertEqual(complex.real, conjugate.real, file: file, line: line)
-        XCTAssertEqual(complex.imaginary, -conjugate.imaginary, file: file, line: line)
+        CTAssertEqual(complex.real, conjugate.real)
+        CTAssertEqual(complex.imaginary, -conjugate.imaginary)
 
         conjugate = complex
         conjugate.formConjugate()
-        XCTAssertEqual(complex.real, conjugate.real, file: file, line: line)
-        XCTAssertEqual(complex.imaginary, -conjugate.imaginary, file: file, line: line)
+        CTAssertEqual(complex.real, conjugate.real)
+        CTAssertEqual(complex.imaginary, -conjugate.imaginary)
     }
 
     private func testNegationMethods<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
         var negative = -complex
-        XCTAssertEqual(complex.real, -negative.real, file: file, line: line)
-        XCTAssertEqual(complex.imaginary, -negative.imaginary, file: file, line: line)
+        CTAssertEqual(complex.real, -negative.real)
+        CTAssertEqual(complex.imaginary, -negative.imaginary)
 
         negative = complex
         negative.negate()
-        XCTAssertEqual(complex.real, -negative.real, file: file, line: line)
-        XCTAssertEqual(complex.imaginary, -negative.imaginary, file: file, line: line)
+        CTAssertEqual(complex.real, -negative.real)
+        CTAssertEqual(complex.imaginary, -negative.imaginary)
     }
 
     private func testMultiplyByOne<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
         let one = Complex<Scalar>.one
         let result = complex * one
 
-        XCTAssertEqual(result, complex, file: file, line: line)
+        CTAssertEqual(result, complex)
     }
 
     private func testMultiplyByI<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: SignedNumeric {
         let i = Complex<Scalar>.i
         let result = complex * i
 
-        XCTAssertEqual(result.real, -complex.imaginary, file: file, line: line)
-        XCTAssertEqual(result.imaginary, complex.real, file: file, line: line)
+        CTAssertEqual(result.real, -complex.imaginary)
+        CTAssertEqual(result.imaginary, complex.real)
     }
 
     private func testPlusPrefixOperator<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(complex, +complex, file: file, line: line)
+        CTAssertEqual(complex, +complex)
     }
 
     private func testPolarComponents<Scalar>(_ complex: Complex<Scalar>, file: StaticString = #file, line: UInt = #line) where Scalar: BinaryFloatingPoint {
-        XCTAssertEqual(complex.modulus, sqrt(complex.real * complex.real + complex.imaginary * complex.imaginary), file: file, line: line)
-        XCTAssertEqual(complex.angle, Scalar(atan2(Float80(complex.imaginary), Float80(complex.real))), file: file, line: line)
+        CTAssertEqual(complex.modulus, sqrt(complex.real * complex.real + complex.imaginary * complex.imaginary))
+        CTAssertEqual(complex.angle, Scalar(atan2(Float80(complex.imaginary), Float80(complex.real))))
     }
 }

--- a/Tests/ComplexTests/FunctionsTests.swift
+++ b/Tests/ComplexTests/FunctionsTests.swift
@@ -14,143 +14,143 @@ class FunctionsTests: XCTestCase {
     // MARK: Test Methods
 
     func test_csqrt() {
-        XCTAssertEqual(csqrt(Half(-4.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(csqrt(Half(9.0)), Complex(real: 3.0, imaginary: 0.0))
+        CTAssertEqual(csqrt(Half(-4.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(csqrt(Half(9.0)), Complex(real: 3.0, imaginary: 0.0))
 
-        XCTAssertEqual(csqrt(Float(-4.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(csqrt(Float(9.0)), Complex(real: 3.0, imaginary: 0.0))
+        CTAssertEqual(csqrt(Float(-4.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(csqrt(Float(9.0)), Complex(real: 3.0, imaginary: 0.0))
 
-        XCTAssertEqual(csqrt(Double(-4.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(csqrt(Double(9.0)), Complex(real: 3.0, imaginary: 0.0))
+        CTAssertEqual(csqrt(Double(-4.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(csqrt(Double(9.0)), Complex(real: 3.0, imaginary: 0.0))
 
-        XCTAssertEqual(csqrt(Float80(-4.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(csqrt(Float80(9.0)), Complex(real: 3.0, imaginary: 0.0))
+        CTAssertEqual(csqrt(Float80(-4.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(csqrt(Float80(9.0)), Complex(real: 3.0, imaginary: 0.0))
     }
 
     func test_sqrt() {
-        XCTAssertEqual(sqrt(Complex<Half>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(sqrt(Complex<Half>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
-        XCTAssertEqual(sqrt(Complex<Half>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Half>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Half>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
-        XCTAssertEqual(sqrt(Complex<Half>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Half>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Half>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
+        CTAssertEqual(sqrt(Complex<Half>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Half>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Half>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
+        CTAssertEqual(sqrt(Complex<Half>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
 
-        XCTAssertEqual(sqrt(Complex<Float>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(sqrt(Complex<Float>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
-        XCTAssertEqual(sqrt(Complex<Float>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Float>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Float>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
-        XCTAssertEqual(sqrt(Complex<Float>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Float>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Float>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
+        CTAssertEqual(sqrt(Complex<Float>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Float>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Float>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
+        CTAssertEqual(sqrt(Complex<Float>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
 
-        XCTAssertEqual(sqrt(Complex<Double>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(sqrt(Complex<Double>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
-        XCTAssertEqual(sqrt(Complex<Double>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Double>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Double>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
-        XCTAssertEqual(sqrt(Complex<Double>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Double>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Double>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
+        CTAssertEqual(sqrt(Complex<Double>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Double>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Double>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
+        CTAssertEqual(sqrt(Complex<Double>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
 
-        XCTAssertEqual(sqrt(Complex<Float80>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(sqrt(Complex<Float80>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
-        XCTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: -4.0)) - Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot())).modulus < 0.0001)
-        XCTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: 4.0)) - Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot())).modulus < 0.0001)
-        XCTAssertEqual(sqrt(Complex<Float80>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
-        XCTAssertEqual(sqrt(Complex<Float80>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Float80>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Float80>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
+        CTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: -4.0)) - Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot())).modulus < 0.0001)
+        CTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: 4.0)) - Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot())).modulus < 0.0001)
+        CTAssertEqual(sqrt(Complex<Float80>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
+        CTAssertEqual(sqrt(Complex<Float80>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
     }
 
     func test_abs() {
-        XCTAssertEqual(abs(Complex<Half>(real: -4.5, imaginary: 3.7)), Complex<Half>(real: 4.5, imaginary: 3.7))
-        XCTAssertEqual(abs(Complex<Float>(real: -4.5, imaginary: 3.7)), Complex<Float>(real: 4.5, imaginary: 3.7))
-        XCTAssertEqual(abs(Complex<Double>(real: -4.5, imaginary: 3.7)), Complex<Double>(real: 4.5, imaginary: 3.7))
-        XCTAssertEqual(abs(Complex<Float80>(real: -4.5, imaginary: 3.7)), Complex<Float80>(real: 4.5, imaginary: 3.7))
+        CTAssertEqual(abs(Complex<Half>(real: -4.5, imaginary: 3.7)), Complex<Half>(real: 4.5, imaginary: 3.7))
+        CTAssertEqual(abs(Complex<Float>(real: -4.5, imaginary: 3.7)), Complex<Float>(real: 4.5, imaginary: 3.7))
+        CTAssertEqual(abs(Complex<Double>(real: -4.5, imaginary: 3.7)), Complex<Double>(real: 4.5, imaginary: 3.7))
+        CTAssertEqual(abs(Complex<Float80>(real: -4.5, imaginary: 3.7)), Complex<Float80>(real: 4.5, imaginary: 3.7))
     }
 
     func test_min() {
-        XCTAssertEqual(min(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: -4.5, imaginary: 1.2))
-        XCTAssertEqual(min(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: -4.5, imaginary: 1.2))
-        XCTAssertEqual(min(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: -4.5, imaginary: 1.2))
-        XCTAssertEqual(min(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: -4.5, imaginary: 1.2))
+        CTAssertEqual(min(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: -4.5, imaginary: 1.2))
+        CTAssertEqual(min(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: -4.5, imaginary: 1.2))
+        CTAssertEqual(min(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: -4.5, imaginary: 1.2))
+        CTAssertEqual(min(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: -4.5, imaginary: 1.2))
     }
 
     func test_max() {
-        XCTAssertEqual(max(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: 7.0, imaginary: 3.7))
-        XCTAssertEqual(max(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: 7.0, imaginary: 3.7))
-        XCTAssertEqual(max(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: 7.0, imaginary: 3.7))
-        XCTAssertEqual(max(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: 7.0, imaginary: 3.7))
+        CTAssertEqual(max(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: 7.0, imaginary: 3.7))
+        CTAssertEqual(max(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: 7.0, imaginary: 3.7))
+        CTAssertEqual(max(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: 7.0, imaginary: 3.7))
+        CTAssertEqual(max(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: 7.0, imaginary: 3.7))
     }
 
     func test_clamp() {
-        XCTAssertEqual(clamp(Complex<Half>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Half>(real: -4.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 0.0, imaginary: 0.0), Complex(real: 2.0, imaginary: 4.0)), Complex<Half>(real: 0.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Half>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Half>(real: -4.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 0.0, imaginary: 0.0), Complex(real: 2.0, imaginary: 4.0)), Complex<Half>(real: 0.0, imaginary: 3.7))
 
-        XCTAssertEqual(clamp(Complex<Float>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Float>(real: -4.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 0.0, imaginary: 0.0), Complex<Float>(real: 2.0, imaginary: 4.0)), Complex<Float>(real: 0.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Float>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Float>(real: -4.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 0.0, imaginary: 0.0), Complex<Float>(real: 2.0, imaginary: 4.0)), Complex<Float>(real: 0.0, imaginary: 3.7))
 
-        XCTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Double>(real: -4.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 0.0, imaginary: 0.0), Complex<Double>(real: 2.0, imaginary: 4.0)), Complex<Double>(real: 0.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Float80>(real: -4.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 0.0, imaginary: 0.0), Complex<Float80>(real: 2.0, imaginary: 4.0)), Complex<Float80>(real: 0.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Double>(real: -4.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 0.0, imaginary: 0.0), Complex<Double>(real: 2.0, imaginary: 4.0)), Complex<Double>(real: 0.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Float80>(real: -4.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 0.0, imaginary: 0.0), Complex<Float80>(real: 2.0, imaginary: 4.0)), Complex<Float80>(real: 0.0, imaginary: 3.7))
     }
 
     func test_exp() {
-        XCTAssertEqual(exp(Complex<Float>(real: 2.0, imaginary: 0.0)), Complex<Float>(real: exp(2.0), imaginary: 0.0), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Float>(real: 2.0, imaginary: .pi * 0.5)), Complex<Float>(real: 0.0, imaginary: exp(2.0)), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Float>(real: 2.0, imaginary: .pi)), Complex<Float>(real: -exp(2.0), imaginary: 0.0), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Float>(real: 2.0, imaginary: .pi * 1.5)), Complex<Float>(real: 0.0, imaginary: -exp(2.0)), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Double>(real: 2.0, imaginary: 0.0)), Complex<Double>(real: exp(2.0), imaginary: 0.0), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Double>(real: 2.0, imaginary: .pi * 0.5)), Complex<Double>(real: 0.0, imaginary: exp(2.0)), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Double>(real: 2.0, imaginary: .pi)), Complex<Double>(real: -exp(2.0), imaginary: 0.0), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Double>(real: 2.0, imaginary: .pi * 1.5)), Complex<Double>(real: 0.0, imaginary: -exp(2.0)), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Float80>(real: 2.0, imaginary: 0.0)), Complex<Float80>(real: exp(2.0), imaginary: 0.0), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Float80>(real: 2.0, imaginary: .pi * 0.5)), Complex<Float80>(real: 0.0, imaginary: exp(2.0)), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Float80>(real: 2.0, imaginary: .pi)), Complex<Float80>(real: -exp(2.0), imaginary: 0.0), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<Float80>(real: 2.0, imaginary: .pi * 1.5)), Complex<Float80>(real: 0.0, imaginary: -exp(2.0)), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Float>(real: 2.0, imaginary: 0.0)), Complex<Float>(real: exp(2.0), imaginary: 0.0), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Float>(real: 2.0, imaginary: .pi * 0.5)), Complex<Float>(real: 0.0, imaginary: exp(2.0)), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Float>(real: 2.0, imaginary: .pi)), Complex<Float>(real: -exp(2.0), imaginary: 0.0), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Float>(real: 2.0, imaginary: .pi * 1.5)), Complex<Float>(real: 0.0, imaginary: -exp(2.0)), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Double>(real: 2.0, imaginary: 0.0)), Complex<Double>(real: exp(2.0), imaginary: 0.0), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Double>(real: 2.0, imaginary: .pi * 0.5)), Complex<Double>(real: 0.0, imaginary: exp(2.0)), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Double>(real: 2.0, imaginary: .pi)), Complex<Double>(real: -exp(2.0), imaginary: 0.0), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Double>(real: 2.0, imaginary: .pi * 1.5)), Complex<Double>(real: 0.0, imaginary: -exp(2.0)), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Float80>(real: 2.0, imaginary: 0.0)), Complex<Float80>(real: exp(2.0), imaginary: 0.0), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Float80>(real: 2.0, imaginary: .pi * 0.5)), Complex<Float80>(real: 0.0, imaginary: exp(2.0)), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Float80>(real: 2.0, imaginary: .pi)), Complex<Float80>(real: -exp(2.0), imaginary: 0.0), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<Float80>(real: 2.0, imaginary: .pi * 1.5)), Complex<Float80>(real: 0.0, imaginary: -exp(2.0)), accuracy: 0.0001)
     }
 
     func test_log() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(log(complex), Complex<Float>(real: log(complex.modulus), imaginary: complex.angle), accuracy: 0.0001)
+            CTAssertEqual(log(complex), Complex<Float>(real: log(complex.modulus), imaginary: complex.angle), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(log(complex), Complex<Double>(real: log(complex.modulus), imaginary: complex.angle), accuracy: 0.0001)
+            CTAssertEqual(log(complex), Complex<Double>(real: log(complex.modulus), imaginary: complex.angle), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(log(complex), Complex<Float80>(real: log(complex.modulus), imaginary: complex.angle), accuracy: 0.0001)
+            CTAssertEqual(log(complex), Complex<Float80>(real: log(complex.modulus), imaginary: complex.angle), accuracy: 0.0001)
         }
     }
 
     func test_log10() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(log10(complex), log(complex) / log(10), accuracy: 0.0001)
+            CTAssertEqual(log10(complex), log(complex) / log(10), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(log10(complex), log(complex) / log(10), accuracy: 0.0001)
+            CTAssertEqual(log10(complex), log(complex) / log(10), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(log10(complex), log(complex) / log(10), accuracy: 0.0001)
+            CTAssertEqual(log10(complex), log(complex) / log(10), accuracy: 0.0001)
         }
     }
 
     func test_log2() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(log2(complex), log(complex) / log(2), accuracy: 0.0001)
+            CTAssertEqual(log2(complex), log(complex) / log(2), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(log2(complex), log(complex) / log(2), accuracy: 0.0001)
+            CTAssertEqual(log2(complex), log(complex) / log(2), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(log2(complex), log(complex) / log(2), accuracy: 0.0001)
+            CTAssertEqual(log2(complex), log(complex) / log(2), accuracy: 0.0001)
         }
     }
 
     func test_sin() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(sin(complex), Complex<Float>(real: sin(complex.real) * cosh(complex.imaginary), imaginary: cos(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
+            CTAssertEqual(sin(complex), Complex<Float>(real: sin(complex.real) * cosh(complex.imaginary), imaginary: cos(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(sin(complex), Complex<Double>(real: sin(complex.real) * cosh(complex.imaginary), imaginary: cos(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
+            CTAssertEqual(sin(complex), Complex<Double>(real: sin(complex.real) * cosh(complex.imaginary), imaginary: cos(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(sin(complex), Complex<Float80>(real: sin(complex.real) * cosh(complex.imaginary), imaginary: cos(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
+            CTAssertEqual(sin(complex), Complex<Float80>(real: sin(complex.real) * cosh(complex.imaginary), imaginary: cos(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
         }
     }
 
@@ -162,7 +162,7 @@ class FunctionsTests: XCTestCase {
             let result = -.i * log(iz + root)
             //swiftlint:enable identifier_name
 
-            XCTAssertEqual(asin(complex), result, accuracy: 0.0001)
+            CTAssertEqual(asin(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
             //swiftlint:disable identifier_name
@@ -171,7 +171,7 @@ class FunctionsTests: XCTestCase {
             let result = -.i * log(iz + root)
             //swiftlint:enable identifier_name
 
-            XCTAssertEqual(asin(complex), result, accuracy: 0.0001)
+            CTAssertEqual(asin(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
             //swiftlint:disable identifier_name
@@ -180,31 +180,31 @@ class FunctionsTests: XCTestCase {
             let result = -.i * log(iz + root)
             //swiftlint:enable identifier_name
 
-            XCTAssertEqual(asin(complex), result, accuracy: 0.0001)
+            CTAssertEqual(asin(complex), result, accuracy: 0.0001)
         }
     }
 
     func test_sinh() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(sinh(complex), -.i * sin(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(sinh(complex), -.i * sin(.i * complex), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(sinh(complex), -.i * sin(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(sinh(complex), -.i * sin(.i * complex), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(sinh(complex), -.i * sin(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(sinh(complex), -.i * sin(.i * complex), accuracy: 0.0001)
         }
     }
 
     func test_cos() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(cos(complex), Complex<Float>(real: cos(complex.real) * cosh(complex.imaginary), imaginary: -sin(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
+            CTAssertEqual(cos(complex), Complex<Float>(real: cos(complex.real) * cosh(complex.imaginary), imaginary: -sin(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(cos(complex), Complex<Double>(real: cos(complex.real) * cosh(complex.imaginary), imaginary: -sin(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
+            CTAssertEqual(cos(complex), Complex<Double>(real: cos(complex.real) * cosh(complex.imaginary), imaginary: -sin(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(cos(complex), Complex<Float80>(real: cos(complex.real) * cosh(complex.imaginary), imaginary: -sin(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
+            CTAssertEqual(cos(complex), Complex<Float80>(real: cos(complex.real) * cosh(complex.imaginary), imaginary: -sin(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
         }
     }
 
@@ -213,43 +213,43 @@ class FunctionsTests: XCTestCase {
             let root = sqrt((complex * complex) - 1.0)
             let result = -.i * log(complex + root)
 
-            XCTAssertEqual(acos(complex), result, accuracy: 0.0001)
+            CTAssertEqual(acos(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
             let root = sqrt((complex * complex) - 1.0)
             let result = -.i * log(complex + root)
 
-            XCTAssertEqual(acos(complex), result, accuracy: 0.0001)
+            CTAssertEqual(acos(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
             let root = sqrt((complex * complex) - 1.0)
             let result = -.i * log(complex + root)
 
-            XCTAssertEqual(acos(complex), result, accuracy: 0.0001)
+            CTAssertEqual(acos(complex), result, accuracy: 0.0001)
         }
     }
 
     func test_cosh() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(cosh(complex), cos(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(cosh(complex), cos(.i * complex), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(cosh(complex), cos(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(cosh(complex), cos(.i * complex), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(cosh(complex), cos(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(cosh(complex), cos(.i * complex), accuracy: 0.0001)
         }
     }
 
     func test_tan() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(tan(complex), sin(complex) / cos(complex), accuracy: 0.0001)
+            CTAssertEqual(tan(complex), sin(complex) / cos(complex), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(tan(complex), sin(complex) / cos(complex), accuracy: 0.0001)
+            CTAssertEqual(tan(complex), sin(complex) / cos(complex), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(tan(complex), sin(complex) / cos(complex), accuracy: 0.0001)
+            CTAssertEqual(tan(complex), sin(complex) / cos(complex), accuracy: 0.0001)
         }
     }
 
@@ -258,31 +258,31 @@ class FunctionsTests: XCTestCase {
             let quotient = (.i + complex) / (.i - complex)
             let result = .i * 0.5 * log(quotient)
 
-            XCTAssertEqual(atan(complex), result, accuracy: 0.0001)
+            CTAssertEqual(atan(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
             let quotient = (.i + complex) / (.i - complex)
             let result = .i * 0.5 * log(quotient)
 
-            XCTAssertEqual(atan(complex), result, accuracy: 0.0001)
+            CTAssertEqual(atan(complex), result, accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
             let quotient = (.i + complex) / (.i - complex)
             let result = .i * 0.5 * log(quotient)
 
-            XCTAssertEqual(atan(complex), result, accuracy: 0.0001)
+            CTAssertEqual(atan(complex), result, accuracy: 0.0001)
         }
     }
 
     func test_tanh() {
         for complex in sampleComplexNumbers(ofType: Float.self) {
-            XCTAssertEqual(tanh(complex), -.i * tan(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(tanh(complex), -.i * tan(.i * complex), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Double.self) {
-            XCTAssertEqual(tanh(complex), -.i * tan(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(tanh(complex), -.i * tan(.i * complex), accuracy: 0.0001)
         }
         for complex in sampleComplexNumbers(ofType: Float80.self) {
-            XCTAssertEqual(tanh(complex), -.i * tan(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(tanh(complex), -.i * tan(.i * complex), accuracy: 0.0001)
         }
     }
 
@@ -294,9 +294,4 @@ class FunctionsTests: XCTestCase {
                 Complex<Scalar>(real: 2.0, imaginary: .pi),
                 Complex<Scalar>(real: 2.0, imaginary: .pi * 1.5)]
     }
-}
-
-func XCTAssertEqual<T>(_ expression1: @autoclosure () throws -> Complex<T>, _ expression2: @autoclosure () throws -> Complex<T>, accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) rethrows where T: FloatingPoint {
-    let difference = try abs(expression1() - expression2())
-    XCTAssertTrue(difference.real <= accuracy && difference.imaginary <= accuracy, message(), file: file, line: line)
 }

--- a/Tests/ComplexTests/FunctionsTests.swift.gyb
+++ b/Tests/ComplexTests/FunctionsTests.swift.gyb
@@ -14,96 +14,96 @@ class FunctionsTests: XCTestCase {
     // MARK: Test Methods
 
     func test_csqrt() {
-        XCTAssertEqual(csqrt(Half(-4.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(csqrt(Half(9.0)), Complex(real: 3.0, imaginary: 0.0))
+        CTAssertEqual(csqrt(Half(-4.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(csqrt(Half(9.0)), Complex(real: 3.0, imaginary: 0.0))
 
-        XCTAssertEqual(csqrt(Float(-4.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(csqrt(Float(9.0)), Complex(real: 3.0, imaginary: 0.0))
+        CTAssertEqual(csqrt(Float(-4.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(csqrt(Float(9.0)), Complex(real: 3.0, imaginary: 0.0))
 
-        XCTAssertEqual(csqrt(Double(-4.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(csqrt(Double(9.0)), Complex(real: 3.0, imaginary: 0.0))
+        CTAssertEqual(csqrt(Double(-4.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(csqrt(Double(9.0)), Complex(real: 3.0, imaginary: 0.0))
 
-        XCTAssertEqual(csqrt(Float80(-4.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(csqrt(Float80(9.0)), Complex(real: 3.0, imaginary: 0.0))
+        CTAssertEqual(csqrt(Float80(-4.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(csqrt(Float80(9.0)), Complex(real: 3.0, imaginary: 0.0))
     }
 
     func test_sqrt() {
-        XCTAssertEqual(sqrt(Complex<Half>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(sqrt(Complex<Half>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
-        XCTAssertEqual(sqrt(Complex<Half>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Half>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Half>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
-        XCTAssertEqual(sqrt(Complex<Half>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Half>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Half>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
+        CTAssertEqual(sqrt(Complex<Half>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Half>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Half>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
+        CTAssertEqual(sqrt(Complex<Half>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
 
-        XCTAssertEqual(sqrt(Complex<Float>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(sqrt(Complex<Float>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
-        XCTAssertEqual(sqrt(Complex<Float>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Float>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Float>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
-        XCTAssertEqual(sqrt(Complex<Float>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Float>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Float>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
+        CTAssertEqual(sqrt(Complex<Float>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Float>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Float>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
+        CTAssertEqual(sqrt(Complex<Float>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
 
-        XCTAssertEqual(sqrt(Complex<Double>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(sqrt(Complex<Double>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
-        XCTAssertEqual(sqrt(Complex<Double>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Double>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
-        XCTAssertEqual(sqrt(Complex<Double>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
-        XCTAssertEqual(sqrt(Complex<Double>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Double>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Double>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
+        CTAssertEqual(sqrt(Complex<Double>(real: 0.0, imaginary: -4.0)), Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Double>(real: 0.0, imaginary: 4.0)), Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot()))
+        CTAssertEqual(sqrt(Complex<Double>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
+        CTAssertEqual(sqrt(Complex<Double>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
 
-        XCTAssertEqual(sqrt(Complex<Float80>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
-        XCTAssertEqual(sqrt(Complex<Float80>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
-        XCTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: -4.0)) - Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot())).modulus < 0.0001)
-        XCTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: 4.0)) - Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot())).modulus < 0.0001)
-        XCTAssertEqual(sqrt(Complex<Float80>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
-        XCTAssertEqual(sqrt(Complex<Float80>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Float80>(real: -4.0, imaginary: 0.0)), Complex(real: 0.0, imaginary: 2.0))
+        CTAssertEqual(sqrt(Complex<Float80>(real: 4.0, imaginary: 0.0)), Complex(real: 2.0, imaginary: 0.0))
+        CTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: -4.0)) - Complex(real: 2.0.squareRoot(), imaginary: -2.0.squareRoot())).modulus < 0.0001)
+        CTAssertTrue((sqrt(Complex<Float80>(real: 0.0, imaginary: 4.0)) - Complex(real: 2.0.squareRoot(), imaginary: 2.0.squareRoot())).modulus < 0.0001)
+        CTAssertEqual(sqrt(Complex<Float80>(real: 3.0, imaginary: 4.0)), Complex(real: 2.0, imaginary: 1.0))
+        CTAssertEqual(sqrt(Complex<Float80>(real: -3.0, imaginary: 4.0)), Complex(real: 1.0, imaginary: 2.0))
     }
 
     func test_abs() {
-        XCTAssertEqual(abs(Complex<Half>(real: -4.5, imaginary: 3.7)), Complex<Half>(real: 4.5, imaginary: 3.7))
-        XCTAssertEqual(abs(Complex<Float>(real: -4.5, imaginary: 3.7)), Complex<Float>(real: 4.5, imaginary: 3.7))
-        XCTAssertEqual(abs(Complex<Double>(real: -4.5, imaginary: 3.7)), Complex<Double>(real: 4.5, imaginary: 3.7))
-        XCTAssertEqual(abs(Complex<Float80>(real: -4.5, imaginary: 3.7)), Complex<Float80>(real: 4.5, imaginary: 3.7))
+        CTAssertEqual(abs(Complex<Half>(real: -4.5, imaginary: 3.7)), Complex<Half>(real: 4.5, imaginary: 3.7))
+        CTAssertEqual(abs(Complex<Float>(real: -4.5, imaginary: 3.7)), Complex<Float>(real: 4.5, imaginary: 3.7))
+        CTAssertEqual(abs(Complex<Double>(real: -4.5, imaginary: 3.7)), Complex<Double>(real: 4.5, imaginary: 3.7))
+        CTAssertEqual(abs(Complex<Float80>(real: -4.5, imaginary: 3.7)), Complex<Float80>(real: 4.5, imaginary: 3.7))
     }
 
     func test_min() {
-        XCTAssertEqual(min(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: -4.5, imaginary: 1.2))
-        XCTAssertEqual(min(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: -4.5, imaginary: 1.2))
-        XCTAssertEqual(min(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: -4.5, imaginary: 1.2))
-        XCTAssertEqual(min(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: -4.5, imaginary: 1.2))
+        CTAssertEqual(min(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: -4.5, imaginary: 1.2))
+        CTAssertEqual(min(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: -4.5, imaginary: 1.2))
+        CTAssertEqual(min(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: -4.5, imaginary: 1.2))
+        CTAssertEqual(min(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: -4.5, imaginary: 1.2))
     }
 
     func test_max() {
-        XCTAssertEqual(max(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: 7.0, imaginary: 3.7))
-        XCTAssertEqual(max(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: 7.0, imaginary: 3.7))
-        XCTAssertEqual(max(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: 7.0, imaginary: 3.7))
-        XCTAssertEqual(max(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: 7.0, imaginary: 3.7))
+        CTAssertEqual(max(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 7.0, imaginary: 1.2)), Complex<Half>(real: 7.0, imaginary: 3.7))
+        CTAssertEqual(max(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 7.0, imaginary: 1.2)), Complex<Float>(real: 7.0, imaginary: 3.7))
+        CTAssertEqual(max(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 7.0, imaginary: 1.2)), Complex<Double>(real: 7.0, imaginary: 3.7))
+        CTAssertEqual(max(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 7.0, imaginary: 1.2)), Complex<Float80>(real: 7.0, imaginary: 3.7))
     }
 
     func test_clamp() {
-        XCTAssertEqual(clamp(Complex<Half>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Half>(real: -4.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 0.0, imaginary: 0.0), Complex(real: 2.0, imaginary: 4.0)), Complex<Half>(real: 0.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Half>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Half>(real: -4.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Half>(real: -4.5, imaginary: 3.7), Complex<Half>(real: 0.0, imaginary: 0.0), Complex(real: 2.0, imaginary: 4.0)), Complex<Half>(real: 0.0, imaginary: 3.7))
 
-        XCTAssertEqual(clamp(Complex<Float>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Float>(real: -4.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 0.0, imaginary: 0.0), Complex<Float>(real: 2.0, imaginary: 4.0)), Complex<Float>(real: 0.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Float>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Float>(real: -4.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Float>(real: -4.5, imaginary: 3.7), Complex<Float>(real: 0.0, imaginary: 0.0), Complex<Float>(real: 2.0, imaginary: 4.0)), Complex<Float>(real: 0.0, imaginary: 3.7))
 
-        XCTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Double>(real: -4.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 0.0, imaginary: 0.0), Complex<Double>(real: 2.0, imaginary: 4.0)), Complex<Double>(real: 0.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Float80>(real: -4.0, imaginary: 3.7))
-        XCTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 0.0, imaginary: 0.0), Complex<Float80>(real: 2.0, imaginary: 4.0)), Complex<Float80>(real: 0.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Double>(real: -4.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Double>(real: -4.5, imaginary: 3.7), Complex<Double>(real: 0.0, imaginary: 0.0), Complex<Double>(real: 2.0, imaginary: 4.0)), Complex<Double>(real: 0.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), -4.0, 4.0), Complex<Float80>(real: -4.0, imaginary: 3.7))
+        CTAssertEqual(clamp(Complex<Float80>(real: -4.5, imaginary: 3.7), Complex<Float80>(real: 0.0, imaginary: 0.0), Complex<Float80>(real: 2.0, imaginary: 4.0)), Complex<Float80>(real: 0.0, imaginary: 3.7))
     }
 
     func test_exp() {
         % for type in ["Float", "Double", "Float80"]:
-        XCTAssertEqual(exp(Complex<${type}>(real: 2.0, imaginary: 0.0)), Complex<${type}>(real: exp(2.0), imaginary: 0.0), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<${type}>(real: 2.0, imaginary: .pi * 0.5)), Complex<${type}>(real: 0.0, imaginary: exp(2.0)), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<${type}>(real: 2.0, imaginary: .pi)), Complex<${type}>(real: -exp(2.0), imaginary: 0.0), accuracy: 0.0001)
-        XCTAssertEqual(exp(Complex<${type}>(real: 2.0, imaginary: .pi * 1.5)), Complex<${type}>(real: 0.0, imaginary: -exp(2.0)), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<${type}>(real: 2.0, imaginary: 0.0)), Complex<${type}>(real: exp(2.0), imaginary: 0.0), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<${type}>(real: 2.0, imaginary: .pi * 0.5)), Complex<${type}>(real: 0.0, imaginary: exp(2.0)), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<${type}>(real: 2.0, imaginary: .pi)), Complex<${type}>(real: -exp(2.0), imaginary: 0.0), accuracy: 0.0001)
+        CTAssertEqual(exp(Complex<${type}>(real: 2.0, imaginary: .pi * 1.5)), Complex<${type}>(real: 0.0, imaginary: -exp(2.0)), accuracy: 0.0001)
         % end
     }
 
     func test_log() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(log(complex), Complex<${type}>(real: log(complex.modulus), imaginary: complex.angle), accuracy: 0.0001)
+            CTAssertEqual(log(complex), Complex<${type}>(real: log(complex.modulus), imaginary: complex.angle), accuracy: 0.0001)
         }
         % end
     }
@@ -111,7 +111,7 @@ class FunctionsTests: XCTestCase {
     func test_log10() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(log10(complex), log(complex) / log(10), accuracy: 0.0001)
+            CTAssertEqual(log10(complex), log(complex) / log(10), accuracy: 0.0001)
         }
         % end
     }
@@ -119,7 +119,7 @@ class FunctionsTests: XCTestCase {
     func test_log2() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(log2(complex), log(complex) / log(2), accuracy: 0.0001)
+            CTAssertEqual(log2(complex), log(complex) / log(2), accuracy: 0.0001)
         }
         % end
     }
@@ -127,7 +127,7 @@ class FunctionsTests: XCTestCase {
     func test_sin() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(sin(complex), Complex<${type}>(real: sin(complex.real) * cosh(complex.imaginary), imaginary: cos(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
+            CTAssertEqual(sin(complex), Complex<${type}>(real: sin(complex.real) * cosh(complex.imaginary), imaginary: cos(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
         }
         % end
     }
@@ -141,7 +141,7 @@ class FunctionsTests: XCTestCase {
             let result = -.i * log(iz + root)
             //swiftlint:enable identifier_name
 
-            XCTAssertEqual(asin(complex), result, accuracy: 0.0001)
+            CTAssertEqual(asin(complex), result, accuracy: 0.0001)
         }
         % end
     }
@@ -149,7 +149,7 @@ class FunctionsTests: XCTestCase {
     func test_sinh() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(sinh(complex), -.i * sin(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(sinh(complex), -.i * sin(.i * complex), accuracy: 0.0001)
         }
         % end
     }
@@ -157,7 +157,7 @@ class FunctionsTests: XCTestCase {
     func test_cos() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(cos(complex), Complex<${type}>(real: cos(complex.real) * cosh(complex.imaginary), imaginary: -sin(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
+            CTAssertEqual(cos(complex), Complex<${type}>(real: cos(complex.real) * cosh(complex.imaginary), imaginary: -sin(complex.real) * sinh(complex.imaginary)), accuracy: 0.0001)
         }
         % end
     }
@@ -168,7 +168,7 @@ class FunctionsTests: XCTestCase {
             let root = sqrt((complex * complex) - 1.0)
             let result = -.i * log(complex + root)
 
-            XCTAssertEqual(acos(complex), result, accuracy: 0.0001)
+            CTAssertEqual(acos(complex), result, accuracy: 0.0001)
         }
         % end
     }
@@ -176,7 +176,7 @@ class FunctionsTests: XCTestCase {
     func test_cosh() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(cosh(complex), cos(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(cosh(complex), cos(.i * complex), accuracy: 0.0001)
         }
         % end
     }
@@ -184,7 +184,7 @@ class FunctionsTests: XCTestCase {
     func test_tan() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(tan(complex), sin(complex) / cos(complex), accuracy: 0.0001)
+            CTAssertEqual(tan(complex), sin(complex) / cos(complex), accuracy: 0.0001)
         }
         % end
     }
@@ -195,7 +195,7 @@ class FunctionsTests: XCTestCase {
             let quotient = (.i + complex) / (.i - complex)
             let result = .i * 0.5 * log(quotient)
 
-            XCTAssertEqual(atan(complex), result, accuracy: 0.0001)
+            CTAssertEqual(atan(complex), result, accuracy: 0.0001)
         }
         % end
     }
@@ -203,7 +203,7 @@ class FunctionsTests: XCTestCase {
     func test_tanh() {
         % for type in ["Float", "Double", "Float80"]:
         for complex in sampleComplexNumbers(ofType: ${type}.self) {
-            XCTAssertEqual(tanh(complex), -.i * tan(.i * complex), accuracy: 0.0001)
+            CTAssertEqual(tanh(complex), -.i * tan(.i * complex), accuracy: 0.0001)
         }
         % end
     }
@@ -216,9 +216,4 @@ class FunctionsTests: XCTestCase {
                 Complex<Scalar>(real: 2.0, imaginary: .pi),
                 Complex<Scalar>(real: 2.0, imaginary: .pi * 1.5)]
     }
-}
-
-func XCTAssertEqual<T>(_ expression1: @autoclosure () throws -> Complex<T>, _ expression2: @autoclosure () throws -> Complex<T>, accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) rethrows where T: FloatingPoint {
-    let difference = try abs(expression1() - expression2())
-    XCTAssertTrue(difference.real <= accuracy && difference.imaginary <= accuracy, message(), file: file, line: line)
 }

--- a/Tests/ComplexTests/TestingBase.swift
+++ b/Tests/ComplexTests/TestingBase.swift
@@ -1,0 +1,41 @@
+//
+//  TestingBase.swift
+//  Complex
+//
+//  Copyright © 2020 SomeRandomiOSDev. All rights reserved.
+//
+
+@testable import Complex
+import XCTest
+
+// MARK: Internal Methods
+
+internal func CTAssertEqual<T>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", function: String = #function, file: StaticString = #file, line: UInt = #line) where T: Equatable {
+    XCTAssertEqual(try expression1(), try expression2(), "\(testMethodDescription(forType: T.self, function: function))\(message().isEmpty ? "" : ": \(message())")", file: file, line: line)
+}
+
+internal func CTAssertTrue(_ expression: @autoclosure () throws -> Bool, _ message: @autoclosure () -> String = "", function: String = #function, file: StaticString = #file, line: UInt = #line) {
+    XCTAssertTrue(try expression(), "\(function))\(message().isEmpty ? "" : ": \(message())")", file: file, line: line)
+}
+
+internal func CTAssertFalse(_ expression: @autoclosure () throws -> Bool, _ message: @autoclosure () -> String = "", function: String = #function, file: StaticString = #file, line: UInt = #line) {
+    XCTAssertFalse(try expression(), "\(function))\(message().isEmpty ? "" : ": \(message())")", file: file, line: line)
+}
+
+internal func CTAssertEqual<T>(_ expression1: @autoclosure () throws -> Complex<T>, _ expression2: @autoclosure () throws -> Complex<T>, accuracy: T, _ message: @autoclosure () -> String = "", function: String = #function, file: StaticString = #file, line: UInt = #line) rethrows where T: FloatingPoint {
+    let difference = try abs(expression1() - expression2())
+    CTAssertTrue(difference.real <= accuracy && difference.imaginary <= accuracy, message(), function: function, file: file, line: line)
+}
+
+// MARK: - Private Methods
+
+private func testMethodDescription<Scalar>(forType type: Scalar.Type, function: String = #function) -> String {
+    let description: String
+    if let index = function.firstIndex(of: "(") {
+        description = "\(function[..<index])<\(type)>\(function[index...])"
+    } else {
+        description = function
+    }
+
+    return description
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no
+
+ignore:
+  - Tests/**/*


### PR DESCRIPTION
A large number of the tests in this project are setup in a format like follows:

```swift
func testSomeRoutine() {
    testSomeRoutine(forType: Int8.self)
    testSomeRoutine(forType: Int16.self)
    ...
    testSomeRoutine(forType: UInt8.self)
    testSomeRoutine(forType: UInt16.self)
    ...
}
```

Prior to this change, assertions wouldn't notate which passed type caused the test failure. Now, using the new assertion functions `CTAssertTrue`, `CTAssertFalse`, `CTAssertEqual` propagates the name of the method that called it as well type it compares (for `CTAssertEqual`) for better visibility into the function, and more specifically, the type caused a particular test failure.